### PR TITLE
Update battery icon seekbar continuously

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
-    buildToolsVersion '33.0.0 rc1'
+    buildToolsVersion '33.0.0 rc2'
 
     defaultConfig {
         applicationId "sh.siava.AOSPMods"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="battery_show_percent_title">Show battery percentage</string>
     <string name="battery_style_category_title">Battery style</string>
     <string name="battery_style_category_summary" translatable="false">@string/qs_footer_text_desc</string>
-    <string name="battery_icon_size_title">Battery Icon Size</string>
+    <string name="battery_icon_size_title">Battery icon size</string>
     <string name="battery_size_summary" translatable="false">@string/percent_of_default_size</string>
     <string name="battery_hidden">Hidden</string>
     <string name="lte_4g_icon_title">LTE / 4G Icon</string>

--- a/app/src/main/res/xml/statusbar_settings.xml
+++ b/app/src/main/res/xml/statusbar_settings.xml
@@ -75,7 +75,8 @@
             <SeekBarPreference
                 android:defaultValue="50"
                 android:key="BatteryIconScaleFactor"
-                app:title="@string/battery_icon_size_title" />
+                android:title="@string/battery_icon_size_title"
+                app:updatesContinuously="true" />
             <SwitchPreference
                 android:defaultValue="false"
                 android:key="BatteryShowPercent"


### PR DESCRIPTION
- Add `app:updatesContinuously="true"` to the `BatteryIconScaleFactor` `SeekBarPreference` so that the displayed value is updated while a user is moving the seekbar (instead of only after the user lifts their finger), making it easier to set a specific value (e.g. 150%).
- Change the corresponding title string from `Battery Icon Size` to `Battery icon size` for consistency with other title strings.
- Update `buildToolsVersion` in `app/build.gradle` from `33.0.0 rc1` to `33.0.0 rc2`, matching the one in `QSTileOverlay/build.gradle`.