### PR TITLE
Add option to remove icon for UDFPS hint

### DIFF
--- a/app/src/main/java/sh/siava/pixelxpert/modpacks/systemui/UDFPSManager.java
+++ b/app/src/main/java/sh/siava/pixelxpert/modpacks/systemui/UDFPSManager.java
@@ -25,6 +25,7 @@ import sh.siava.pixelxpert.modpacks.XposedModPack;
 public class UDFPSManager extends XposedModPack {
 	private static final String listenPackage = Constants.SYSTEM_UI_PACKAGE;
 	private static boolean transparentBG = false;
+	private static boolean transparentFG = false;
 
 	public UDFPSManager(Context context) {
 		super(context);
@@ -34,6 +35,7 @@ public class UDFPSManager extends XposedModPack {
 	public void updatePrefs(String... Key) {
 		if (Xprefs == null) return;
 		transparentBG = Xprefs.getBoolean("fingerprint_circle_hide", false);
+		transparentFG = Xprefs.getBoolean("fingerprint_icon_hide", false);
 	}
 
 	@Override
@@ -71,7 +73,7 @@ public class UDFPSManager extends XposedModPack {
 							new XC_MethodHook() {
 								@Override
 								protected void afterHookedMethod(MethodHookParam param1) throws Throwable {
-									removeUDFPSBG(param.thisObject);
+									removeUDFPSGraphics(param.thisObject);
 								}
 							});
 				} catch (Throwable ignored) {
@@ -82,7 +84,7 @@ public class UDFPSManager extends XposedModPack {
 		hookAllMethods(UdfpsKeyguardViewClass, "onFinishInflate", new XC_MethodHook() { //A13
 			@Override
 			protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-				removeUDFPSBG(param.thisObject);
+				removeUDFPSGraphics(param.thisObject);
 			}
 		});
 
@@ -108,13 +110,21 @@ public class UDFPSManager extends XposedModPack {
 				});
 	}
 
-	private void removeUDFPSBG(Object object) {
-		if (!transparentBG) return;
-
+	private void removeUDFPSGraphics(Object object) {
 		try
 		{
-			ImageView mBgProtection = (ImageView) getObjectField(object, "mBgProtection");
-			mBgProtection.setImageDrawable(new ShapeDrawable());
+			if (transparentBG) {
+				ImageView mBgProtection = (ImageView) getObjectField(object, "mBgProtection");
+				mBgProtection.setImageDrawable(new ShapeDrawable());
+			}
+
+			if (transparentFG) {
+				ImageView mLockScreenFp = (ImageView) getObjectField(object, "mLockScreenFp");
+				mLockScreenFp.setImageDrawable(new ShapeDrawable());
+				
+				ImageView mAodFp = (ImageView) getObjectField(object, "mAodFp");
+				mAodFp.setImageDrawable(new ShapeDrawable());
+			}
 		}
 		catch (Throwable ignored){}
 	}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,9 @@
 	<string name="transparent_fingerprint_circle">Remove background circle from under-display fingerprint</string>
 	<string name="transparent_fingerprint_circle_off">Circle around fingerprint icon is active</string>
 	<string name="transparent_fingerprint_circle_on">Circle around fingerprint icon will be hidden</string>
+	<string name="fingerprint_icon">Remove foreground icon from under-display fingerprint</string>
+	<string name="fingerprint_icon_off">Fingerprint icon is active</string>
+	<string name="fingerprint_icon_on">Fingerprint icon will be hidden</string>
 	<string name="custom_text_category">Custom text on Lockscreen</string>
 	<string name="configure_carrier_text">Configure carrier text - Top of the screen</string>
 	<string name="carrier_text_mod_disabled">Carrier text unchanged</string>

--- a/app/src/main/res/xml/lock_screen_prefs.xml
+++ b/app/src/main/res/xml/lock_screen_prefs.xml
@@ -35,6 +35,14 @@
 
 		<sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
 			android:defaultValue="false"
+			android:key="fingerprint_icon_hide"
+			android:summaryOff="@string/fingerprint_icon_off"
+			android:summaryOn="@string/fingerprint_icon_on"
+			android:title="@string/fingerprint_icon"
+			app:iconSpaceReserved="false" />
+
+		<sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
+			android:defaultValue="false"
 			android:key="DisableUnlockHintAnimation"
 			android:summaryOff="@string/general_off"
 			android:summaryOn="@string/general_on"


### PR DESCRIPTION
Similar to the option to remove the background circle for it, this one instead removes the actual fingerprint icon. This allows you to visually hide that you have an UDFPS, if desired, or just remove the icon for a cleaner look.

I'm not sure how adding new translations are handled here so I only added English translations as that is the language I speak. If there is some other protocol involved in adding the translations, I'd be happy to follow it.