### PR TITLE
Dynamically set background of header preferences

### DIFF
--- a/app/src/main/java/sh/siava/pixelxpert/ui/preferences/MaterialPreferenceMain.java
+++ b/app/src/main/java/sh/siava/pixelxpert/ui/preferences/MaterialPreferenceMain.java
@@ -1,7 +1,6 @@
 package sh.siava.pixelxpert.ui.preferences;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.ViewGroup;
@@ -9,48 +8,30 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceGroup;
 import androidx.preference.PreferenceViewHolder;
 
 import sh.siava.pixelxpert.R;
 
 public class MaterialPreferenceMain extends Preference {
 
-	private static final int POSITION_TOP = 0;
-	private static final int POSITION_DEFAULT = 1;
-	private static final int POSITION_SINGLE = 2;
-	private static final int POSITION_BOTTOM = 3;
-
-	private int position = POSITION_DEFAULT;
-
 	public MaterialPreferenceMain(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
 		super(context, attrs, defStyleAttr, defStyleRes);
-		init(context, attrs);
+		initResource();
 	}
 
 	public MaterialPreferenceMain(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
 		super(context, attrs, defStyleAttr);
-		init(context, attrs);
+		initResource();
 	}
 
 	public MaterialPreferenceMain(@NonNull Context context, @Nullable AttributeSet attrs) {
 		super(context, attrs);
-		init(context, attrs);
+		initResource();
 	}
 
 	public MaterialPreferenceMain(@NonNull Context context) {
 		super(context);
-		initResource();
-	}
-
-	private void init(Context context, @Nullable AttributeSet attrs) {
-		if (attrs != null) {
-			TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.MaterialPreferenceMain, 0, 0);
-			try {
-				position = a.getInt(R.styleable.MaterialPreferenceMain_position, POSITION_DEFAULT);
-			} finally {
-				a.recycle();
-			}
-		}
 		initResource();
 	}
 
@@ -78,21 +59,27 @@ public class MaterialPreferenceMain extends Preference {
 			}
 		}
 
-		// Set background drawable based on the position attribute
-		switch (position) {
-			case POSITION_TOP:
-				holder.itemView.setBackgroundResource(R.drawable.container_top);
-				break;
-			case POSITION_SINGLE:
+		setBackgroundResource(holder);
+	}
+
+	private void setBackgroundResource(PreferenceViewHolder holder) {
+		PreferenceGroup parent = getParent();
+
+		if (parent != null) {
+			int itemCount = parent.getPreferenceCount();
+			int position = getOrder();
+
+			if (itemCount == 1) {
 				holder.itemView.setBackgroundResource(R.drawable.container_single);
-				break;
-			case POSITION_BOTTOM:
-				holder.itemView.setBackgroundResource(R.drawable.container_bottom);
-				break;
-			case POSITION_DEFAULT:
-			default:
-				holder.itemView.setBackgroundResource(R.drawable.container_mid);
-				break;
+			} else if (itemCount > 1) {
+				if (position == 0) {
+					holder.itemView.setBackgroundResource(R.drawable.container_top);
+				} else if (position == itemCount - 1) {
+					holder.itemView.setBackgroundResource(R.drawable.container_bottom);
+				} else {
+					holder.itemView.setBackgroundResource(R.drawable.container_mid);
+				}
+			}
 		}
 	}
 }

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -11,13 +11,4 @@
 		<attr name="textNoResults" format="string" />
 		<attr name="textClearHistory" format="string" />
 	</declare-styleable>
-
-	<declare-styleable name="MaterialPreferenceMain">
-		<attr name="position" format="string">
-			<enum name="topItem" value="0" />
-			<enum name="defaultItem" value="1" />
-			<enum name="singleItem" value="2" />
-			<enum name="bottomItem" value="3" />
-		</attr>
-	</declare-styleable>
 </resources>

--- a/app/src/main/res/xml/header_preferences.xml
+++ b/app/src/main/res/xml/header_preferences.xml
@@ -21,7 +21,6 @@
 			app:fragment="sh.siava.pixelxpert.ui.activities.SettingsActivity$QuickSettingsFragment"
 			app:icon="@drawable/ic_settings_quicksettings"
 			app:key="quicksettings_header"
-			app:position="topItem"
 			app:summary="@string/qs_panel_category_summary"
 			app:title="@string/qs_panel_category_title"
 			search:ignore="true" />
@@ -40,7 +39,6 @@
 			app:fragment="sh.siava.pixelxpert.ui.activities.SettingsActivity$ThemingFragment"
 			app:icon="@drawable/ic_settings_themes"
 			app:key="theming_header"
-			app:position="bottomItem"
 			app:summary="@string/theme_customization_summary"
 			app:title="@string/theme_customization_category"
 			search:ignore="true" />
@@ -58,7 +56,6 @@
 			app:fragment="sh.siava.pixelxpert.ui.activities.SettingsActivity$StatusbarFragment"
 			app:icon="@drawable/ic_settings_statusbar"
 			app:key="statusbar_header"
-			app:position="topItem"
 			app:summary="@string/statusbar_header_summary"
 			app:title="@string/statusbar_header"
 			search:ignore="true" />
@@ -68,7 +65,6 @@
 			app:fragment="sh.siava.pixelxpert.ui.activities.SettingsActivity$NavFragment"
 			app:icon="@drawable/ic_settings_navigation"
 			app:key="nav_header"
-			app:position="bottomItem"
 			app:summary="@string/nav_header_summary"
 			app:title="@string/nav_header"
 			search:ignore="true" />
@@ -86,7 +82,6 @@
 			app:fragment="sh.siava.pixelxpert.ui.activities.SettingsActivity$DialerFragment"
 			app:icon="@drawable/ic_phone"
 			app:key="dialer_header"
-			app:position="topItem"
 			app:summary="@string/dialer_header_summary"
 			app:title="@string/dialer_header"
 			search:ignore="true" />
@@ -114,7 +109,6 @@
 			app:fragment="sh.siava.pixelxpert.ui.activities.SettingsActivity$MiscFragment"
 			app:icon="@drawable/ic_settings_misc"
 			app:key="misc_header"
-			app:position="bottomItem"
 			app:summary="@string/misc_header_summary"
 			app:title="@string/misc_header"
 			search:ignore="true" />


### PR DESCRIPTION
This update enhances the dynamic setting of the background drawable for `MaterialPreferenceMain`. Instead of relying on custom attributes `app:position="topItem|defaultItem|singleItem|bottomItem"`, the background drawable will now be dynamically adjusted based on the position of the item and the total count of its parent items. This change improves flexibility and ensures consistent appearance across different item configurations.