### PR TITLE
TaskBar updates

### DIFF
--- a/app/src/main/java/sh/siava/pixelxpert/modpacks/launcher/TaskbarActivator.java
+++ b/app/src/main/java/sh/siava/pixelxpert/modpacks/launcher/TaskbarActivator.java
@@ -64,6 +64,7 @@ public class TaskbarActivator extends XposedModPack {
 	private Object recentTasksList;
 	private static boolean TaskbarAsRecents = false;
 	private static boolean TaskbarTransient = false;
+	private static boolean TaskbarOnLauncher = false;
 	private boolean refreshing = false;
 	private static float taskbarHeightOverride = 1f;
 	private static float TaskbarRadiusOverride = 1f;
@@ -140,6 +141,8 @@ public class TaskbarActivator extends XposedModPack {
 
 		TaskbarTransient = Xprefs.getBoolean("TaskbarTransient", false);
 
+		TaskbarOnLauncher = Xprefs.getBoolean("TaskbarOnLauncher", false);
+
 	}
 
 	@Override
@@ -163,6 +166,7 @@ public class TaskbarActivator extends XposedModPack {
 		ReflectedClass BaseActivityClass = ReflectedClass.of("com.android.launcher3.BaseActivity");
 		ReflectedClass DisplayControllerClass = ReflectedClass.of("com.android.launcher3.util.DisplayController");
 		ReflectedClass DisplayControllerInfoClass = ReflectedClass.of("com.android.launcher3.util.DisplayController$Info");
+		ReflectedClass StateControllerClass = ReflectedClass.of("com.android.launcher3.taskbar.TaskbarLauncherStateController");
 		Method commitItemsToUIMethod = findMethodExact(TaskbarModelCallbacksClass.getClazz(), "commitItemsToUI");
 		ReflectedClass AbstractNavButtonLayoutterClass = ReflectedClass.of("com.android.launcher3.taskbar.navbutton.AbstractNavButtonLayoutter");
 
@@ -203,6 +207,14 @@ public class TaskbarActivator extends XposedModPack {
 				.run(param -> {
 					if (taskbarMode == TASKBAR_ON && model != null) {
 						XposedHelpers.callMethod(model, "onAppIconChanged", BuildConfig.APPLICATION_ID, UserHandle.getUserHandleForUid(0));
+					}
+				});
+
+		StateControllerClass
+				.after("isInLauncher")
+				.run(param -> {
+					if (TaskbarOnLauncher) {
+						param.setResult(false);
 					}
 				});
 

--- a/app/src/main/java/sh/siava/pixelxpert/modpacks/launcher/TaskbarActivator.java
+++ b/app/src/main/java/sh/siava/pixelxpert/modpacks/launcher/TaskbarActivator.java
@@ -131,7 +131,7 @@ public class TaskbarActivator extends XposedModPack {
 		taskbarMode = Integer.parseInt(Xprefs.getString("taskBarMode", String.valueOf(TASKBAR_DEFAULT)));
 
 		TaskbarAsRecents = Xprefs.getBoolean("TaskbarAsRecents", false);
-		TaskbarHideAllAppsIcon = true;//Xprefs.getBoolean("TaskbarHideAllAppsIcon", false);
+		TaskbarHideAllAppsIcon = Xprefs.getBoolean("TaskbarHideAllAppsIcon", true);
 
 		TaskbarRadiusOverride = Xprefs.getSliderFloat("TaskbarRadiusOverride", 1f);
 
@@ -319,7 +319,7 @@ public class TaskbarActivator extends XposedModPack {
 		TaskbarViewClass
 				.after(mUpdateItemsMethodName)
 				.run(param -> {
-					if(TaskbarAsRecents) {
+					if(TaskbarAsRecents && TaskbarHideAllAppsIcon) {
 						try {
 							View container = (View) getObjectField(param.thisObject, "mAllAppsButtonContainer");
 							ViewGroup taskbarView = (ViewGroup) param.thisObject;
@@ -423,7 +423,8 @@ public class TaskbarActivator extends XposedModPack {
 									callMethod(taskBarView, mUpdateItemsMethodName, new Object[]{itemInfos});
 								}
 
-								int startPoint = taskBarView.getChildAt(0).getClass().getName().endsWith("SearchDelegateView") ? 1 : 0;
+								int firstAppIcon = TaskbarHideAllAppsIcon ? 0 : 2;
+								int startPoint = taskBarView.getChildAt(firstAppIcon).getClass().getName().endsWith("SearchDelegateView") ? firstAppIcon + 1 : firstAppIcon;
 
 								for (int i = 0; i < itemInfos.length; i++) {
 									View iconView = taskBarView.getChildAt(i + startPoint);

--- a/app/src/main/java/sh/siava/pixelxpert/modpacks/launcher/TaskbarActivator.java
+++ b/app/src/main/java/sh/siava/pixelxpert/modpacks/launcher/TaskbarActivator.java
@@ -65,6 +65,7 @@ public class TaskbarActivator extends XposedModPack {
 	private static boolean TaskbarAsRecents = false;
 	private static boolean TaskbarTransient = false;
 	private static boolean TaskbarOnLauncher = false;
+	private static boolean GoogleRecents = false;
 	private boolean refreshing = false;
 	private static float taskbarHeightOverride = 1f;
 	private static float TaskbarRadiusOverride = 1f;
@@ -122,7 +123,8 @@ public class TaskbarActivator extends XposedModPack {
 				"TaskbarTransient",
 				"taskbarHeightOverride",
 				"TaskbarRadiusOverride",
-				"TaskbarHideAllAppsIcon");
+				"TaskbarHideAllAppsIcon",
+				"EnableGoogleRecents");
 
 		if (Key.length > 0 && restartKeys.contains(Key[0])) {
 			SystemUtils.killSelf();
@@ -143,6 +145,7 @@ public class TaskbarActivator extends XposedModPack {
 
 		TaskbarOnLauncher = Xprefs.getBoolean("TaskbarOnLauncher", false);
 
+		GoogleRecents = Xprefs.getBoolean("EnableGoogleRecents", false);
 	}
 
 	@Override
@@ -169,6 +172,7 @@ public class TaskbarActivator extends XposedModPack {
 		ReflectedClass StateControllerClass = ReflectedClass.of("com.android.launcher3.taskbar.TaskbarLauncherStateController");
 		Method commitItemsToUIMethod = findMethodExact(TaskbarModelCallbacksClass.getClazz(), "commitItemsToUI");
 		ReflectedClass AbstractNavButtonLayoutterClass = ReflectedClass.of("com.android.launcher3.taskbar.navbutton.AbstractNavButtonLayoutter");
+		ReflectedClass RecentAppsControllerClass = ReflectedClass.of("com.android.launcher3.taskbar.TaskbarRecentAppsController");
 
 		AbstractNavButtonLayoutterClass
 				.afterConstruction()
@@ -461,6 +465,12 @@ public class TaskbarActivator extends XposedModPack {
 					});
 					param.setResult(null);
 				});
+
+		RecentAppsControllerClass.afterConstruction().run(param -> {
+			if (GoogleRecents) {
+				ReflectionTools.findMethod(RecentAppsControllerClass.getClazz(), "setCanShowRecentApps").invoke(param.thisObject, true);
+			}
+		});
 		//endregion
 	}
 

--- a/app/src/main/java/sh/siava/pixelxpert/utils/PreferenceHelper.java
+++ b/app/src/main/java/sh/siava/pixelxpert/utils/PreferenceHelper.java
@@ -86,6 +86,9 @@ public class PreferenceHelper {
 				int taskBarMode = Integer.parseInt(instance.mPreferences.getString("taskBarMode", "0"));
 				return taskBarMode == 1;
 
+			case "TaskbarHideAllAppsIcon":
+                return instance.mPreferences.getBoolean("TaskbarAsRecents", false);
+
 			case "gsans_override":
 			case "FontsOverlayEx":
 				if (!showFonts)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -352,6 +352,7 @@
     <string name="taskbar_force_enable_title">Force Enabled</string>
     <string name="taskbar_force_disable_title">Force Disabled</string>
     <string name="taskbar_transient_title">Auto hide</string>
+    <string name="taskbar_on_launcher_title">Show on home</string>
     <string name="remap_physical_buttons_title">Remap physical buttons</string>
 
     <!-- Package manager -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,6 +343,7 @@
     <string name="pill_width_summary" translatable="false">@string/percent_of_default_size</string>
     <string name="hide_navbar_title">Hide navigation bar</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to recents bar</string>
+    <string name="taskbar_hide_allapps_title">Hide All apps button</string>
     <string name="taskbar_height_title">Taskbar height</string>
     <string name="taskbar_radius_title">Taskbar corner curve</string>
     <string name="colorpill">Accent colored gesture pill</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,8 +342,9 @@
     <string name="three_button_right_title">Right button</string>
     <string name="pill_width_summary" translatable="false">@string/percent_of_default_size</string>
     <string name="hide_navbar_title">Hide navigation bar</string>
-    <string name="taskbar_as_recents_title">Convert Taskbar to recents bar</string>
+    <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_hide_allapps_title">Hide All apps button</string>
+    <string name="taskbar_enable_google_recents">Enable Google recents on the Taskbar</string>
     <string name="taskbar_height_title">Taskbar height</string>
     <string name="taskbar_radius_title">Taskbar corner curve</string>
     <string name="colorpill">Accent colored gesture pill</string>

--- a/app/src/main/res/xml/nav_prefs.xml
+++ b/app/src/main/res/xml/nav_prefs.xml
@@ -44,13 +44,6 @@
 		android:title="@string/taskbar_status_title"
 		app:iconSpaceReserved="false" />
 
-	<!--SwitchPreference
-		android:defaultValue="false"
-		android:key="TaskbarHideAllAppsIcon"
-		android:summaryOff="@string/general_off"
-		android:summaryOn="@string/general_on"
-		android:title="@string/taskbar_hide_allapps_title" /-->
-
 	<sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
 		android:defaultValue="false"
 		android:key="TaskbarTransient"
@@ -68,12 +61,20 @@
 		app:iconSpaceReserved="false" />
 
 	<sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
-		android:defaultValue="false"
+		android:defaultValue="true"
 		android:key="TaskbarAsRecents"
 		android:summaryOff="@string/general_off"
 		android:summaryOn="@string/general_on"
 		android:title="@string/taskbar_as_recents_title"
 		app:iconSpaceReserved="false" />
+
+	<sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
+		android:defaultValue="true"
+		android:key="TaskbarHideAllAppsIcon"
+		android:summaryOff="@string/general_off"
+		android:summaryOn="@string/general_on"
+		android:title="@string/taskbar_hide_allapps_title"
+		app:iconSpaceReserved="false"/>
 
 	<sh.siava.pixelxpert.ui.preferences.MaterialRangeSliderPreference
 		android:key="taskbarHeightOverride"

--- a/app/src/main/res/xml/nav_prefs.xml
+++ b/app/src/main/res/xml/nav_prefs.xml
@@ -61,6 +61,14 @@
 
 	<sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
 		android:defaultValue="false"
+		android:key="TaskbarOnLauncher"
+		android:summaryOff="@string/general_off"
+		android:summaryOn="@string/general_on"
+		android:title="@string/taskbar_on_launcher_title"
+		app:iconSpaceReserved="false" />
+
+	<sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
+		android:defaultValue="false"
 		android:key="TaskbarAsRecents"
 		android:summaryOff="@string/general_off"
 		android:summaryOn="@string/general_on"

--- a/app/src/main/res/xml/nav_prefs.xml
+++ b/app/src/main/res/xml/nav_prefs.xml
@@ -76,6 +76,14 @@
 		android:title="@string/taskbar_hide_allapps_title"
 		app:iconSpaceReserved="false"/>
 
+	<sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
+		android:defaultValue="false"
+		android:key="EnableGoogleRecents"
+		android:summaryOff="@string/general_off"
+		android:summaryOn="@string/general_on"
+		android:title="@string/taskbar_enable_google_recents"
+		app:iconSpaceReserved="false" />
+
 	<sh.siava.pixelxpert.ui.preferences.MaterialRangeSliderPreference
 		android:key="taskbarHeightOverride"
 		android:title="@string/taskbar_height_title"


### PR DESCRIPTION
This PR adds 3 new functionalities to the Taskbar:

# Option to also show Taskbar on the Home Screen

This is especially useful with the 3rd party launchers, where taskbar disappears on opening Launcher and does not reappear.

# Option to keep "All apps" button when using PixelXpert recents

Currently, PixelXpert recents implementation removed those buttons. This adds a toggle that can bring them back.

I've noticed there was some similar code for this already in, but commented out. So I reused large chunk of it.

# Option to enable native recents implementation in the Pixel Launcher

It seems like with recent updates, (I think 15 QPR1?), Pixel Launcher now has native recents functionality, but it is hidden. New toggle is added to enable it. To reduce confusion, I have renamed previous recents button to "PixelXpert recents".