### PR TITLE
Update customize.sh to allow installation on Pixel 10 series

### DIFF
--- a/MagiskModBase/customize.sh
+++ b/MagiskModBase/customize.sh
@@ -131,7 +131,7 @@ assertPixelRom()
 
 assert16QPR()
 {
-	if [ -z $(getprop ro.build.id | grep -e "BP[345]") ]; then
+	if [ -z $(getprop ro.build.id | grep -e "BP[345]" -e "BD[345]") ]; then
 		ui_print 'This build is not compatible with'
     ui_print 'your ROM. Please install the stable'
     ui_print 'version 4.3.x instead'


### PR DESCRIPTION
Build ID for 16QPR1 starts with BP3A for all Pixel devices up to Pixel 9 series; Pixel 10 series starts with BD3A. So the assert16QPR function caused installation to fail on Pixel 10 devices. This change simply keeps intact but adds for the grep function to check for either BP3 -OR- BD3, so it shouldn't break anything or open the possibility of PX being installed on an incompatible device.

PS: I don't really use GitHub much and this is I believe my first pull request, so hopefully I'm doing this correctly. Thanks so much for PixelXpert btw, I couldn't live without it!