### PR TITLE
HideNavigationBarInsets

### DIFF
--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/HideNavigationBarInsets.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/HideNavigationBarInsets.java
@@ -1,0 +1,76 @@
+package sh.siava.pixelxpert.xposed.modpacks.launcher;
+
+import static sh.siava.pixelxpert.xposed.XPrefs.Xprefs;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.view.WindowManager;
+
+import java.lang.reflect.Array;
+
+import de.robv.android.xposed.XposedHelpers;
+import de.robv.android.xposed.callbacks.XC_LoadPackage;
+import sh.siava.pixelxpert.xposed.XposedModPack;
+import sh.siava.pixelxpert.xposed.annotations.LauncherModPack;
+import sh.siava.pixelxpert.xposed.utils.SystemUtils;
+import sh.siava.pixelxpert.xposed.utils.toolkit.ReflectedClass;
+
+@LauncherModPack
+public class HideNavigationBarInsets extends XposedModPack {
+    private boolean HideNavbarInsets;
+
+    public HideNavigationBarInsets(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void onPreferenceUpdated(String... Key) {
+        HideNavbarInsets = Xprefs.getBoolean("HideNavbarInsets", false);
+        if (Key.length > 0 && Key[0].equals("HideNavbarInsets")) {
+            SystemUtils.killSelf();
+        }
+    }
+
+    @SuppressLint("DiscouragedApi")
+    @Override
+    public void onPackageLoaded(XC_LoadPackage.LoadPackageParam lpParam) throws Throwable {
+        ReflectedClass TaskbarActivityContextClass = ReflectedClass.of("com.android.launcher3.taskbar.TaskbarActivityContext");
+        TaskbarActivityContextClass
+                .before("notifyUpdateLayoutParams")
+                .run(param -> {
+                    if (!HideNavbarInsets)
+                        return;
+
+                    WindowManager.LayoutParams layoutParams = (WindowManager.LayoutParams) XposedHelpers.getObjectField(param.thisObject, "mWindowLayoutParams");
+                    transformLayoutParams(layoutParams);
+
+                    WindowManager.LayoutParams[] rotationParams = (WindowManager.LayoutParams[]) XposedHelpers.getObjectField(layoutParams, "paramsForRotation");
+                    if (rotationParams == null)
+                        return;
+
+                    for (WindowManager.LayoutParams rotationLayoutParams : rotationParams)
+                        transformLayoutParams(rotationLayoutParams);
+                });
+    }
+
+    private void transformLayoutParams(WindowManager.LayoutParams layoutParams) {
+        if (layoutParams == null)
+            return;
+
+        Object providedInsets = XposedHelpers.getObjectField(layoutParams, "providedInsets");
+        if (providedInsets == null)
+            return;
+
+        int providedInsetsLength = Array.getLength(providedInsets);
+        for (int i = 0; i < providedInsetsLength; i++) {
+            Object insetsFrame = Array.get(providedInsets, i);
+
+            if (insetsFrame == null)
+                continue;
+            if (!insetsFrame.toString().contains("type=navigationBars")) // no constants, maximum compatibility with Android versions
+                continue;
+
+            XposedHelpers.callMethod(insetsFrame, "setInsetsSize", android.graphics.Insets.NONE);
+        }
+    }
+}

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Middel knoppie</string>
     <string name="three_button_right_title">Regs knoppie</string>
     <string name="hide_navbar_title">Versteek navigasiebalk</string>
+    <string name="hide_navbar_insets_title">Versteek navigasiebalk-insetsels</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Taakbalk hoogte</string>

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">زر الوسط</string>
     <string name="three_button_right_title">زر اليمين</string>
     <string name="hide_navbar_title">إخفاء شريط التنقل</string>
+    <string name="hide_navbar_insets_title">إخفاء إدخالات شريط التنقل</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">ارتفاع شريط المهام</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Středové tlačítko</string>
     <string name="three_button_right_title">Pravé tlačítko</string>
     <string name="hide_navbar_title">Skrýt navigační lištu</string>
+    <string name="hide_navbar_insets_title">Skrýt vložky navigačního panelu</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Výška hlavního panelu</string>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Midterknap</string>
     <string name="three_button_right_title">Højre knap</string>
     <string name="hide_navbar_title">Skjul navigationslinjen</string>
+    <string name="hide_navbar_insets_title">Skjul navigationslinjeindsatser</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Højde på proceslinjen</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Mittler Knopf</string>
     <string name="three_button_right_title">Rechter Knopf</string>
     <string name="hide_navbar_title">Verstecke Gestennavigationsleiste</string>
+    <string name="hide_navbar_insets_title">Navigationsleisteneinsätze ausblenden</string>
     <string name="taskbar_as_recents_title">Konvertieren Sie die Taskbar zu PixelXpert\'s Recents-Leiste</string>
     <string name="taskbar_enable_google_recents">Aktiviere Android Recents in der Taskleiste</string>
     <string name="taskbar_height_title">Höhe der Taskleiste</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Κεντρικό κουμπί</string>
     <string name="three_button_right_title">Δεξί κουμπί</string>
     <string name="hide_navbar_title">Απόκρυψη γραμμής πλοήγησης</string>
+    <string name="hide_navbar_insets_title">Απόκρυψη ενθέτων γραμμής πλοήγησης</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Ύψος γραμμής εργασιών</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Botón central</string>
     <string name="three_button_right_title">Botón derecho</string>
     <string name="hide_navbar_title">Ocultar barra de navegación</string>
+    <string name="hide_navbar_insets_title">Ocultar inserciones de la barra de navegación</string>
     <string name="taskbar_as_recents_title">Convierte la barra de tareas a la barra de recientes PixelXpert</string>
     <string name="taskbar_enable_google_recents">Activar recientes de Android en la barra de tareas</string>
     <string name="taskbar_height_title">Altura de la barra de tareas</string>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">دکمه وسط</string>
     <string name="three_button_right_title">دکمه سمت راست</string>
     <string name="hide_navbar_title">پنهان کردن نوار ناوبری</string>
+    <string name="hide_navbar_insets_title">پنهان کردن ورودی نوار ناوبری</string>
     <string name="taskbar_as_recents_title">تبدیل نوار وظیفه را به نوار اخیر PixelXpert</string>
     <string name="taskbar_enable_google_recents">فعال کردن اخیراً اندروید در نوار وظیفه</string>
     <string name="taskbar_height_title">ارتفاع نوار برنامه</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Keskipainike</string>
     <string name="three_button_right_title">Oikea painike</string>
     <string name="hide_navbar_title">Piilota navigointipalkki</string>
+    <string name="hide_navbar_insets_title">Piilota navigointipalkin sisäosat</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Tehtäväpalkin korkeus</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Bouton central</string>
     <string name="three_button_right_title">Bouton droit</string>
     <string name="hide_navbar_title">Cacher la barre de navigation</string>
+    <string name="hide_navbar_insets_title">Masquer les incrustations de la barre de navigation</string>
     <string name="taskbar_as_recents_title">Convertir la barre des tâches en récente barre PixelXpert</string>
     <string name="taskbar_enable_google_recents">Activer les applications récentes Android dans la barre de tâches</string>
     <string name="taskbar_height_title">Hauteur de la TaskBar</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">मध्य बटन</string>
     <string name="three_button_right_title">दायां बटन</string>
     <string name="hide_navbar_title">जेस्चर नेविगेशन बार छुपाएं</string>
+    <string name="hide_navbar_insets_title">नेविगेशन बार इनसेट छुपाएं</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">टास्कबार की ऊंचाई</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Középső gomb</string>
     <string name="three_button_right_title">Jobb gomb</string>
     <string name="hide_navbar_title">Navigációs sáv elrejtése</string>
+    <string name="hide_navbar_insets_title">Navigációs sáv betétek elrejtése</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Tálca magassága</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Pulsante centrale</string>
     <string name="three_button_right_title">Pulsante destro</string>
     <string name="hide_navbar_title">Nascondi NavBar</string>
+    <string name="hide_navbar_insets_title">Nascondi gli inserti della barra di navigazione</string>
     <string name="taskbar_as_recents_title">Converti la barra delle applicazioni nella barra delle applicazioni recenti PixelXpert</string>
     <string name="taskbar_enable_google_recents">Abilita i recenti di Android sulla barra delle applicazioni</string>
     <string name="taskbar_height_title">Altezza taskbar</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">中央のボタン</string>
     <string name="three_button_right_title">右のボタン</string>
     <string name="hide_navbar_title">ナビゲーションバーを非表示</string>
+    <string name="hide_navbar_insets_title">ナビゲーションバーのインセットを非表示にする</string>
     <string name="taskbar_as_recents_title">タスクバーをPixelXpertのアプリ履歴バーに切り替える</string>
     <string name="taskbar_enable_google_recents">タスクバーにアプリ履歴を表示する</string>
     <string name="taskbar_height_title">タスクバーの高さ</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">가운데 버튼</string>
     <string name="three_button_right_title">오른쪽 버튼</string>
     <string name="hide_navbar_title">네비게이션 바 숨기기</string>
+    <string name="hide_navbar_insets_title">탐색 모음 삽입물 숨기기</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">작업표시줄 높이</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Middelste knop</string>
     <string name="three_button_right_title">Rechter knop</string>
     <string name="hide_navbar_title">Navigatiebalk verbergen</string>
+    <string name="hide_navbar_insets_title">Insets voor navigatiebalken verbergen</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Hoogte van de taakbalk</string>

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Midtknapp</string>
     <string name="three_button_right_title">Høyre knapp</string>
     <string name="hide_navbar_title">Skjul navigasjonslinjen</string>
+    <string name="hide_navbar_insets_title">Skjul navigasjonslinjeinnsatser</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Høyde på oppgavelinjen</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Środkowy przycisk</string>
     <string name="three_button_right_title">Prawy przycisk</string>
     <string name="hide_navbar_title">Ukryj pasek nawigacyjny</string>
+    <string name="hide_navbar_insets_title">Ukryj wstawki paska nawigacji</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Wysokość paska zadań</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Botão central</string>
     <string name="three_button_right_title">Botão da direita</string>
     <string name="hide_navbar_title">Esconder a barra de navegação</string>
+    <string name="hide_navbar_insets_title">Ocultar inserções da barra de navegação</string>
     <string name="taskbar_as_recents_title">Converter barra de tarefas para apps recentes</string>
     <string name="taskbar_enable_google_recents">Ativar Apos Recentes na Barra de Tarefas</string>
     <string name="taskbar_height_title">Altura da barra de tarefas</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Butonul de mijloc</string>
     <string name="three_button_right_title">Butonul din dreapta</string>
     <string name="hide_navbar_title">Ascunde bara de navigare</string>
+    <string name="hide_navbar_insets_title">Ascundeți inserțiile barei de navigare</string>
     <string name="taskbar_as_recents_title">Convertește bara de activități în bara de recente PixelXpert</string>
     <string name="taskbar_enable_google_recents">Activează Recente Android pe bara de activități</string>
     <string name="taskbar_height_title">Înălțime bară de activități</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Центральная кнопка</string>
     <string name="three_button_right_title">Правая кнопка</string>
     <string name="hide_navbar_title">Скрыть панель жестов</string>
+    <string name="hide_navbar_insets_title">Скрыть область панели навигации</string>
     <string name="taskbar_as_recents_title">Преобразование панели задач в панель недавних PixelXpert</string>
     <string name="taskbar_enable_google_recents">Использовать недавние приложения Android на панели задач</string>
     <string name="taskbar_height_title">Высота панели задач</string>

--- a/app/src/main/res/values-sr-rSP/strings.xml
+++ b/app/src/main/res/values-sr-rSP/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Централно дугме</string>
     <string name="three_button_right_title">Десно дугме</string>
     <string name="hide_navbar_title">Сакриј траку за навигацију</string>
+    <string name="hide_navbar_insets_title">Сакриј уметке траке за навигацију</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Висина траке задатака</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Mittknappen</string>
     <string name="three_button_right_title">Höger knapp</string>
     <string name="hide_navbar_title">Dölj navigeringsfältet</string>
+    <string name="hide_navbar_insets_title">Dölj infällningar i navigeringsfältet</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Aktivitetsfältets höjd</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Orta düğme</string>
     <string name="three_button_right_title">Sağ düğme</string>
     <string name="hide_navbar_title">Gezinme çubuğunu gizle</string>
+    <string name="hide_navbar_insets_title">Gezinme çubuğu eklerini gizle</string>
     <string name="taskbar_as_recents_title">Görev çubuğunu PixelXpert son uygulamalar çubuğuna dönüştür</string>
     <string name="taskbar_enable_google_recents">Görev Çubuğunda Android son uygulamaları etkinleştir</string>
     <string name="taskbar_height_title">Görev çubuğu yüksekliği</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Центральна кнопка</string>
     <string name="three_button_right_title">Права кнопка</string>
     <string name="hide_navbar_title">Сховати панель навігації</string>
+    <string name="hide_navbar_insets_title">Приховати вставки панелі навігації</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Висота панелі завдань</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">Phím trung tâm</string>
     <string name="three_button_right_title">Phím bên phải</string>
     <string name="hide_navbar_title">Ẩn thanh điều hướng</string>
+    <string name="hide_navbar_insets_title">Ẩn thanh điều hướng insets</string>
     <string name="taskbar_as_recents_title">Chuyển đổi Thanh tác vụ thành Thanh gần đây PixelXpert</string>
     <string name="taskbar_enable_google_recents">Bật ứng dụng gần đây trên Thanh tác vụ</string>
     <string name="taskbar_height_title">Chiều cao thanh tác vụ</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">中按钮</string>
     <string name="three_button_right_title">右按钮</string>
     <string name="hide_navbar_title">隐藏小白条</string>
+    <string name="hide_navbar_insets_title">隐藏导航栏插入</string>
     <string name="taskbar_as_recents_title">将任务栏替换为 PixelXpert 最近任务栏</string>
     <string name="taskbar_enable_google_recents">在任务栏上启用 Android 最近任务</string>
     <string name="taskbar_height_title">任务栏高度</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -269,6 +269,7 @@
     <string name="three_button_center_title">中按鈕</string>
     <string name="three_button_right_title">右按鈕</string>
     <string name="hide_navbar_title">隱藏小白條</string>
+    <string name="hide_navbar_insets_title">隐藏导航栏插入</string>
     <string name="taskbar_as_recents_title">將工作列替換為最近工作列</string>
     <string name="taskbar_enable_google_recents">在工作列上啟用 Android 最近任務</string>
     <string name="taskbar_height_title">工作列高度</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,6 +285,7 @@
     <string name="three_button_right_title">Right button</string>
     <string name="pill_width_summary" translatable="false">@string/percent_of_default_size</string>
     <string name="hide_navbar_title">Hide navigation bar</string>
+    <string name="hide_navbar_insets_title">Hide navigation bar insets</string>
     <string name="taskbar_as_recents_title">Convert Taskbar to PixelXpert recents bar</string>
     <string name="taskbar_enable_google_recents">Enable Android recents on the Taskbar</string>
     <string name="taskbar_height_title">Taskbar height</string>

--- a/app/src/main/res/xml/nav_prefs.xml
+++ b/app/src/main/res/xml/nav_prefs.xml
@@ -33,4 +33,12 @@
 		android:title="@string/hide_navbar_title"
 		app:iconSpaceReserved="false" />
 
+	<sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
+		android:defaultValue="false"
+		android:key="HideNavbarInsets"
+		android:summaryOff="@string/general_off"
+		android:summaryOn="@string/general_on"
+		android:title="@string/hide_navbar_insets_title"
+		app:iconSpaceReserved="false" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Many applications still do not support Edge-to-Edge mode, which reserves empty space at the bottom of the screen for system navigation. I suggest adding a “Hide Navigation Bar Insets” feature. It resets the size of the reserved area (Insets), allowing apps to stretch across the entire screen. At the same time, system gestures remain fully functional, and the visual “black background” disappears.