### PR TITLE
Recent icons & re-add IME taskbar

### DIFF
--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/TaskbarActivator.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/TaskbarActivator.java
@@ -13,6 +13,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.view.ViewGroup;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -285,6 +286,7 @@ public class TaskbarActivator extends XposedModPack {
 					}
 				});
 
+		// TaskbarShowAllRecents Pre-16QPR2
 		RecentAppsControllerClass
 				.before("computeShownRecentTasks")
 				.run(param -> {
@@ -298,6 +300,16 @@ public class TaskbarActivator extends XposedModPack {
 						param.setResult(dedupedTasks);
 					}
 				});
+
+		// TaskbarShowAllRecents 16QPR2
+		RecentAppsControllerClass.after("onRecentsOrHotseatChanged").run(param -> {
+			if (TaskbarShowAllRecents) {
+				ArrayList allRecentTasks = (ArrayList) getObjectField(param.thisObject, "allRecentTasks");
+				setObjectField(param.thisObject, "shownTasks", allRecentTasks.subList(0, allRecentTasks.size() - 1));
+				callMethod(param.thisObject, "fetchIcons");
+			}
+		});
+
 
 		// Show taskbar even with keyboard displayed
 		// Pre 16 QPR2

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/TaskbarActivator.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/TaskbarActivator.java
@@ -300,11 +300,20 @@ public class TaskbarActivator extends XposedModPack {
 				});
 
 		// Show taskbar even with keyboard displayed
+		// Pre 16 QPR2
 		TaskbarStashControllerClass.after("shouldStashForIme").run (param -> {
 			if (TaskbarOnIme) {
 				param.setResult(false);
 			}
 		});
+
+		// 16 QPR2
+		TaskbarActivityContextClass.before("isImeDocked").run(param -> {
+			if (TaskbarOnIme) {
+				param.setResult(false);
+			}
+		});
+
 
 		RecentAppsControllerClass
 				.before("onRecentsOrHotseatChanged")

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/TaskbarActivator.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/TaskbarActivator.java
@@ -40,6 +40,7 @@ public class TaskbarActivator extends XposedModPack {
 	private static boolean TaskbarAsRecents = false;
 	private static boolean TaskbarOnLauncher = false;
 	private static boolean GoogleRecents = false;
+	private static boolean TaskbarShowAllRecents = false;
 	private static float taskbarHeightOverride = 1f;
 	private static float TaskbarRadiusOverride = 1f;
 
@@ -108,6 +109,8 @@ public class TaskbarActivator extends XposedModPack {
 		TaskbarOnLauncher = Xprefs.getBoolean("TaskbarOnLauncher", false);
 
 		GoogleRecents = Xprefs.getBoolean("EnableGoogleRecents", false);
+
+		TaskbarShowAllRecents = Xprefs.getBoolean("ShowAllRecentIcons", false);
 	}
 
 	@SuppressLint("DiscouragedApi")
@@ -236,6 +239,20 @@ public class TaskbarActivator extends XposedModPack {
 						RecentAppsControllerClass.findMethods(
 								Pattern.compile("setCanShowRecentApps")).stream().findFirst().get()
 								.invoke(param.thisObject, true);
+					}
+				});
+
+		RecentAppsControllerClass
+				.before("computeShownRecentTasks")
+				.run(param -> {
+					if (TaskbarShowAllRecents) {
+						Object dedupedTasks = callMethod(param.thisObject,
+								"dedupeHotseatTasks",
+								getObjectField(param.thisObject, "allRecentTasks"),
+								getObjectField(param.thisObject, "shownHotseatItems")
+						);
+
+						param.setResult(dedupedTasks);
 					}
 				});
 

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/TaskbarActivator.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/TaskbarActivator.java
@@ -39,6 +39,7 @@ public class TaskbarActivator extends XposedModPack {
 	private static int numShownHotseatIcons = 0;
 	private static boolean TaskbarAsRecents = false;
 	private static boolean TaskbarOnLauncher = false;
+	private static boolean TaskbarOnIme = false;
 	private static boolean GoogleRecents = false;
 	private static boolean TaskbarShowAllRecents = false;
 	private static float taskbarHeightOverride = 1f;
@@ -108,6 +109,8 @@ public class TaskbarActivator extends XposedModPack {
 
 		TaskbarOnLauncher = Xprefs.getBoolean("TaskbarOnLauncher", false);
 
+		TaskbarOnIme = Xprefs.getBoolean("TaskbarOnIme", false);
+
 		GoogleRecents = Xprefs.getBoolean("EnableGoogleRecents", false);
 
 		TaskbarShowAllRecents = Xprefs.getBoolean("ShowAllRecentIcons", false);
@@ -128,6 +131,7 @@ public class TaskbarActivator extends XposedModPack {
 		ReflectedClass QuickSwitchStateClass = ReflectedClass.of("com.android.launcher3.uioverrides.states.QuickSwitchState");
 		ReflectedClass TaskbarUiControllerClass = ReflectedClass.of("com.android.launcher3.taskbar.FallbackTaskbarUIController");
 		ReflectedClass TaskbarProfileClass = ReflectedClass.of("com.android.launcher3.deviceprofile.TaskbarProfile");
+		ReflectedClass TaskbarStashControllerClass = ReflectedClass.of("com.android.launcher3.taskbar.TaskbarStashController");
 
 		//3 button nav order on A15+
 		AbstractNavButtonLayoutterClass
@@ -255,6 +259,13 @@ public class TaskbarActivator extends XposedModPack {
 						param.setResult(dedupedTasks);
 					}
 				});
+
+		// Show taskbar even with keyboard displayed
+		TaskbarStashControllerClass.after("shouldStashForIme").run (param -> {
+			if (TaskbarOnIme) {
+				param.setResult(false);
+			}
+		});
 
 		RecentAppsControllerClass
 				.before("onRecentsOrHotseatChanged")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,6 +297,7 @@
     <string name="taskbar_on_launcher_title">Show on home</string>
     <string name="remap_physical_buttons_title">Remap physical buttons</string>
     <string name="taskbar_on_ime_title">Show with keyboard open</string>
+    <string name="taskbar_show_all_recents_icons">Show more recent app icons</string>
 
     <!-- Package manager -->
     <string name="pm_bypass_signature_title">Bypass package signature check</string>

--- a/app/src/main/res/xml/taskbar_prefs.xml
+++ b/app/src/main/res/xml/taskbar_prefs.xml
@@ -25,6 +25,14 @@
         app:iconSpaceReserved="false" />
 
     <sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
+        android:defaultValue="false"
+        android:key="TaskbarOnIme"
+        android:summaryOff="@string/general_off"
+        android:summaryOn="@string/general_on"
+        android:title="@string/taskbar_on_ime_title"
+        app:iconSpaceReserved="false" />
+
+    <sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
         android:defaultValue="true"
         android:key="TaskbarAsRecents"
         android:summaryOff="@string/general_off"

--- a/app/src/main/res/xml/taskbar_prefs.xml
+++ b/app/src/main/res/xml/taskbar_prefs.xml
@@ -68,4 +68,12 @@
         app:tickInterval=".1"
         app:updatesContinuously="false" />
 
+    <sh.siava.pixelxpert.ui.preferences.MaterialSwitchPreference
+        android:defaultValue="false"
+        android:key="ShowAllRecentIcons"
+        android:summaryOff="@string/general_off"
+        android:summaryOn="@string/general_on"
+        android:title="@string/taskbar_show_all_recents_icons"
+        app:iconSpaceReserved="false" />
+
 </PreferenceScreen>


### PR DESCRIPTION
PR adds two things:

1. More statusbar recents toggle:

<img width="862" height="72" alt="image" src="https://github.com/user-attachments/assets/e142bc0b-d869-4fa7-a174-66db9256cfc8" />

2. It reverts removal of the "Show taskbar on the IME" option (https://github.com/siavash79/PixelXpert/commit/882b2b321489e342c6f27934f0941d0249e14cad). Not sure why that option was removed, it still works fine for me on the 16 BP3A.