### PR TITLE
[codex] Fix resized no-cutout status bar layout

### DIFF
--- a/app/src/main/java/sh/siava/pixelxpert/xposed/XPLauncher.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/XPLauncher.java
@@ -24,16 +24,20 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import io.github.libxposed.api.XposedModule;
 import io.github.libxposed.api.XposedModuleInterface;
+import io.github.libxposed.api.XposedInterface;
 import sh.siava.pixelxpert.BuildConfig;
 import sh.siava.pixelxpert.IPixelXpertProxy;
 import sh.siava.pixelxpert.R;
 import sh.siava.pixelxpert.service.PixelXpertProxy;
+import sh.siava.pixelxpert.xposed.modpacks.android.StatusbarSize;
+import sh.siava.pixelxpert.xposed.utils.ExtendedRemotePreferences;
 import sh.siava.pixelxpert.xposed.utils.SystemUtils;
 import sh.siava.pixelxpert.xposed.utils.reflection.ReflectedClass;
 import sh.siava.pixelxpert.xposed.utils.toolkit.Logger;
@@ -50,6 +54,8 @@ public class XPLauncher extends XposedModule implements ServiceConnection {
 	private CountDownLatch rootProxyCountdown = new CountDownLatch(1);
 	private static IPixelXpertProxy rootProxyIPC;
 	private static final Queue<ProxyRunnable> proxyQueue = new LinkedList<>();
+	private static boolean EARLY_SYSTEM_CONTEXT_HOOK_INSTALLED = false;
+	private static boolean EARLY_SYSTEM_SERVER_HOOKS_INSTALLED = false;
 	private static boolean TELECOM_SERVER_LOADED = false;
 	public static Resources moduleResources;
 
@@ -70,7 +76,15 @@ public class XPLauncher extends XposedModule implements ServiceConnection {
 	@Override
 	public void onSystemServerStarting(@NonNull XposedModuleInterface.SystemServerStartingParam SSSP)
 	{
+		ReflectedClass.setDefaultXposedInterface(this);
 		ReflectedClass.setFrameworkClassloader(SSSP.getClassLoader());
+		try {
+			StatusbarSize.installEarlyNoCutoutHook(SSSP.getClassLoader(), false);
+			hookEarlySystemContextStatusBarSize(SSSP.getClassLoader());
+			hookEarlySystemServerStatusBarSize(SSSP.getClassLoader());
+		} catch (Throwable t) {
+			Logger.log(t);
+		}
 	}
 
 	private static void hook17BetaAudioManagerSRWorkaround(PackageReadyParam PRParam) {
@@ -90,6 +104,8 @@ public class XPLauncher extends XposedModule implements ServiceConnection {
 		hook17BetaAudioManagerSRWorkaround(PRParam);
 
 		if (isSystemServer && !PRParam.getPackageName().equals(Constants.TELECOM_SERVER_PACKAGE)) {
+			hookEarlySystemServerStatusBarSize(PRParam.getClassLoader());
+
 			ReflectedClass PhoneWindowManagerClass = ReflectedClass.of("com.android.server.policy.PhoneWindowManager");
 
 			PhoneWindowManagerClass
@@ -135,6 +151,74 @@ public class XPLauncher extends XposedModule implements ServiceConnection {
 				}
 			});
 		}
+	}
+
+	private void hookEarlySystemServerStatusBarSize(ClassLoader classLoader) {
+		if (EARLY_SYSTEM_SERVER_HOOKS_INSTALLED) return;
+
+		try {
+			Set<XposedInterface.HookHandle> hooks = ReflectedClass.of("com.android.server.wm.WindowManagerService", classLoader)
+					.before("main")
+					.run(instance, param -> {
+						try {
+							updateEarlyStatusBarSizePrefs((Context) param.args[0], classLoader);
+						} catch (Throwable t) {
+							Logger.log(t);
+						}
+					});
+			EARLY_SYSTEM_SERVER_HOOKS_INSTALLED = !hooks.isEmpty();
+			if (!EARLY_SYSTEM_SERVER_HOOKS_INSTALLED) {
+				Logger.log("PixelXpert: failed to find WindowManagerService.main for early status bar hooks");
+			}
+		} catch (Throwable t) {
+			Logger.log(t);
+		}
+	}
+
+	private void hookEarlySystemContextStatusBarSize(ClassLoader classLoader) {
+		if (EARLY_SYSTEM_CONTEXT_HOOK_INSTALLED) return;
+
+		try {
+			Set<XposedInterface.HookHandle> hooks = ReflectedClass.of("com.android.server.SystemServer", classLoader)
+					.after("createSystemContext")
+					.run(this, param -> {
+						try {
+							updateEarlyStatusBarSizePrefs((Context) getObjectField(param.thisObject, "mSystemContext"), classLoader);
+						} catch (Throwable t) {
+							Logger.log(t);
+						}
+					});
+			EARLY_SYSTEM_CONTEXT_HOOK_INSTALLED = !hooks.isEmpty();
+			if (!EARLY_SYSTEM_CONTEXT_HOOK_INSTALLED) {
+				Logger.log("PixelXpert: failed to find SystemServer.createSystemContext for early status bar hooks");
+			}
+		} catch (Throwable t) {
+			Logger.log(t);
+		}
+	}
+
+	private static void updateEarlyStatusBarSizePrefs(Context context, ClassLoader classLoader) {
+		boolean noCutoutEnabled = getEarlyBooleanPref(context, "noCutoutEnabled", false);
+		StatusbarSize.installEarlyNoCutoutHook(classLoader, noCutoutEnabled);
+	}
+
+	private static boolean getEarlyBooleanPref(Context context, String key, boolean defaultValue) {
+		try {
+			ExtendedRemotePreferences prefs = new ExtendedRemotePreferences(context, APPLICATION_ID, APPLICATION_ID + "_preferences", true);
+			return prefs.getBoolean(key, defaultValue);
+		} catch (Throwable ignored) {
+		}
+
+		try {
+			Context moduleContext = context.createPackageContext(APPLICATION_ID, CONTEXT_IGNORE_SECURITY)
+					.createDeviceProtectedStorageContext();
+			return moduleContext
+					.getSharedPreferences(APPLICATION_ID + "_preferences", Context.MODE_PRIVATE)
+					.getBoolean(key, defaultValue);
+		} catch (Throwable ignored) {
+		}
+
+		return defaultValue;
 	}
 
 	private void waitForXprefsLoad(PackageReadyParam PRParam) {

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/android/StatusbarSize.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/android/StatusbarSize.java
@@ -4,19 +4,26 @@ package sh.siava.pixelxpert.xposed.modpacks.android;
 
 import static de.robv.android.xposed.XposedHelpers.getObjectField;
 import static de.robv.android.xposed.XposedHelpers.getStaticObjectField;
+import static de.robv.android.xposed.XposedHelpers.callMethod;
+import static de.robv.android.xposed.XposedHelpers.setIntField;
 import static sh.siava.pixelxpert.xposed.XPrefs.Xprefs;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.graphics.Insets;
 import android.graphics.Rect;
 import android.view.DisplayCutout;
+import android.view.View;
+import android.view.WindowManager;
 
 import io.github.libxposed.api.XposedModuleInterface;
 import sh.siava.pixelxpert.xposed.XposedModPack;
 import sh.siava.pixelxpert.xposed.annotations.FrameworkModPack;
 import sh.siava.pixelxpert.xposed.annotations.SystemUIModPack;
 import sh.siava.pixelxpert.xposed.utils.reflection.ReflectedClass;
+import sh.siava.pixelxpert.xposed.utils.toolkit.Logger;
 
 
 //We are playing in system framework. should be extra cautious..... many try-catchs, still not enough!
@@ -28,6 +35,7 @@ public class StatusbarSize extends XposedModPack {
 
 	static int sizeFactor = 100; // % of normal
 	static boolean noCutoutEnabled = true;
+	private static boolean sNoCutoutHookInstalled = false;
 	int currentHeight = 0;
 	boolean edited = false; //if we touched it once during this instance, we'll have to continue setting it even if it's the original value
 	private boolean mForceApplyHeight = false;
@@ -56,15 +64,124 @@ public class StatusbarSize extends XposedModPack {
 			conf.orientation = Configuration.ORIENTATION_PORTRAIT;
 			Context portraitContext = mContext.createConfigurationContext(conf);
 
-			currentHeight = Math.round(
-					portraitContext.getResources().getDimensionPixelSize(
-							portraitContext.getResources().getIdentifier(
-									"status_bar_height",
-									"dimen",
-									"android")
-					)
-							* sizeFactor
-							/ 100f);
+			currentHeight = Math.round(getPortraitStatusBarHeight(portraitContext) * sizeFactor / 100f);
+		}
+	}
+
+	private static int getPortraitStatusBarHeight(Context context) {
+		Resources resources = context.getResources();
+		int id = resources.getIdentifier("status_bar_height_portrait", "dimen", "android");
+		if (id == 0) {
+			id = resources.getIdentifier("status_bar_height", "dimen", "android");
+		}
+		return resources.getDimensionPixelSize(id);
+	}
+
+	private boolean shouldApplyHeight() {
+		return sizeFactor != 100 || edited || mForceApplyHeight;
+	}
+
+	private void applyCachedStatusBarHeight(Object statusBarWindowController) {
+		if (!shouldApplyHeight()) return;
+
+		setIntField(statusBarWindowController, "mBarHeight", currentHeight);
+	}
+
+	private void applyStatusBarLayoutParams(Object layoutParams) {
+		if (!shouldApplyHeight() || !(layoutParams instanceof WindowManager.LayoutParams lp)) return;
+
+		if (lp.type == WindowManager.LayoutParams.TYPE_STATUS_BAR) {
+			lp.height = currentHeight;
+			applyStatusBarLayoutParams(getLayoutParamsArray(lp, "paramsForRotation"));
+			applyInsetsFrameProviders(getObjectArray(lp, "providedInsets"));
+		}
+	}
+
+	private void applyStatusBarLayoutParams(WindowManager.LayoutParams[] paramsForRotation) {
+		if (paramsForRotation == null) return;
+
+		for (WindowManager.LayoutParams rotationParams : paramsForRotation) {
+			if (rotationParams != null) {
+				rotationParams.height = currentHeight;
+				applyInsetsFrameProviders(getObjectArray(rotationParams, "providedInsets"));
+			}
+		}
+	}
+
+	private WindowManager.LayoutParams[] getLayoutParamsArray(Object target, String fieldName) {
+		try {
+			Object value = getObjectField(target, fieldName);
+			return value instanceof WindowManager.LayoutParams[] ? (WindowManager.LayoutParams[]) value : null;
+		} catch (Throwable ignored) {
+			return null;
+		}
+	}
+
+	private Object[] getObjectArray(Object target, String fieldName) {
+		try {
+			Object value = getObjectField(target, fieldName);
+			return value instanceof Object[] ? (Object[]) value : null;
+		} catch (Throwable ignored) {
+			return null;
+		}
+	}
+
+	private void applyInsetsFrameProviders(Object[] providers) {
+		if (providers == null) return;
+
+		Insets insets = Insets.of(0, currentHeight, 0, 0);
+		for (Object provider : providers) {
+			if (provider == null) continue;
+
+			try {
+				callMethod(provider, "setInsetsSize", insets);
+			} catch (Throwable ignored) {
+			}
+		}
+	}
+
+	private void syncStatusBarLayoutParams(Object statusBarWindowController, boolean updateWindow) {
+		if (!shouldApplyHeight()) return;
+
+		try {
+			applyCachedStatusBarHeight(statusBarWindowController);
+			applyStatusBarLayoutParams(getObjectField(statusBarWindowController, "mLpChanged"));
+
+			Object layoutParams = getObjectField(statusBarWindowController, "mLp");
+			applyStatusBarLayoutParams(layoutParams);
+
+			if (updateWindow && layoutParams instanceof WindowManager.LayoutParams) {
+				Object windowManager = getObjectField(statusBarWindowController, "mWindowManager");
+				Object statusBarWindowView = getObjectField(statusBarWindowController, "mStatusBarWindowView");
+				if (windowManager != null && statusBarWindowView instanceof View) {
+					callMethod(windowManager, "updateViewLayout", statusBarWindowView, layoutParams);
+				}
+			}
+		} catch (Throwable ignored) {
+		}
+	}
+
+	public static void installEarlyNoCutoutHook(ClassLoader classLoader, boolean enabled) {
+		noCutoutEnabled = enabled;
+		if (sNoCutoutHookInstalled) return;
+
+		try {
+			ReflectedClass WmDisplayCutoutClass = ReflectedClass.of("com.android.server.wm.utils.WmDisplayCutout", classLoader);
+			ReflectedClass DisplayCutoutClass = ReflectedClass.of("android.view.DisplayCutout", classLoader);
+
+			Object NO_CUTOUT = getStaticObjectField(DisplayCutoutClass.getClazz(), "NO_CUTOUT");
+
+			WmDisplayCutoutClass
+					.before("getDisplayCutout")
+					.run(param -> {
+						if (noCutoutEnabled) {
+							param.setResult(NO_CUTOUT);
+						}
+			});
+
+			sNoCutoutHookInstalled = true;
+		} catch (Throwable t) {
+			Logger.log("StatusbarSize: failed to install early display cutout hook", t);
 		}
 	}
 
@@ -72,22 +189,13 @@ public class StatusbarSize extends XposedModPack {
 	public void onPackageLoaded(XposedModuleInterface.PackageReadyParam PRParam) throws Throwable {
 		try {
 			try {
+				installEarlyNoCutoutHook(PRParam.getClassLoader(), noCutoutEnabled);
+
 				ReflectedClass WmDisplayCutoutClass = ReflectedClass.of("com.android.server.wm.utils.WmDisplayCutout");
-				ReflectedClass DisplayCutoutClass = ReflectedClass.of("android.view.DisplayCutout");
-
-				Object NO_CUTOUT = getStaticObjectField(DisplayCutoutClass.getClazz(), "NO_CUTOUT");
-
-				WmDisplayCutoutClass
-						.before("getDisplayCutout")
-						.run(param -> {
-							if (noCutoutEnabled) {
-								param.setResult(NO_CUTOUT);
-							}
-						});
-
 				WmDisplayCutoutClass
 						.after("getDisplayCutout")
 						.run(param -> {
+							if (noCutoutEnabled) return;
 							if (sizeFactor >= 100 && !edited) return;
 
 							DisplayCutout displayCutout = (DisplayCutout) param.getResult();
@@ -110,7 +218,7 @@ public class StatusbarSize extends XposedModPack {
 
 			ReflectedClass.ReflectionConsumer resizedResultConsumer = param -> {
 				try {
-					if (sizeFactor == 100 && !edited && !mForceApplyHeight) return;
+					if (!shouldApplyHeight()) return;
 					edited = true;
 					param.setResult(currentHeight);
 				} catch (Throwable ignored) {
@@ -122,6 +230,30 @@ public class StatusbarSize extends XposedModPack {
 
 				SystemBarUtilsClass.before("getStatusBarHeight").run(resizedResultConsumer);
 				SystemBarUtilsClass.before("getStatusBarHeightForRotation").run(resizedResultConsumer);
+			} catch (Throwable ignored) {
+			}
+
+			try {
+				ReflectedClass StatusBarWindowControllerImplClass =
+						ReflectedClass.ofIfPossible("com.android.systemui.statusbar.window.StatusBarWindowControllerImpl");
+				ReflectedClass.ReflectionConsumer cachedStatusBarHeightConsumer = param -> {
+					try {
+						applyCachedStatusBarHeight(param.thisObject);
+					} catch (Throwable ignored) {
+					}
+				};
+
+				StatusBarWindowControllerImplClass.afterConstruction().run(cachedStatusBarHeightConsumer);
+				StatusBarWindowControllerImplClass.before("attach").run(cachedStatusBarHeightConsumer);
+				StatusBarWindowControllerImplClass.before("applyHeight").run(cachedStatusBarHeightConsumer);
+				StatusBarWindowControllerImplClass.before("refreshStatusBarHeight").run(cachedStatusBarHeightConsumer);
+				StatusBarWindowControllerImplClass.before("getStatusBarHeight").run(resizedResultConsumer);
+				StatusBarWindowControllerImplClass.after("attach").run(param -> syncStatusBarLayoutParams(param.thisObject, true));
+				StatusBarWindowControllerImplClass.after("apply").run(param -> syncStatusBarLayoutParams(param.thisObject, true));
+				StatusBarWindowControllerImplClass.after("applyHeight").run(param -> syncStatusBarLayoutParams(param.thisObject, false));
+				StatusBarWindowControllerImplClass.after("refreshStatusBarHeight").run(param -> syncStatusBarLayoutParams(param.thisObject, true));
+				StatusBarWindowControllerImplClass.after("getBarLayoutParams").run(param -> applyStatusBarLayoutParams(param.getResult()));
+				StatusBarWindowControllerImplClass.after("getBarLayoutParamsForRotation").run(param -> applyStatusBarLayoutParams(param.getResult()));
 			} catch (Throwable ignored) {
 			}
 		} catch (Throwable ignored) {

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/HideNavigationBarInsets.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/HideNavigationBarInsets.java
@@ -9,11 +9,11 @@ import android.view.WindowManager;
 import java.lang.reflect.Array;
 
 import de.robv.android.xposed.XposedHelpers;
-import de.robv.android.xposed.callbacks.XC_LoadPackage;
+import io.github.libxposed.api.XposedModuleInterface;
 import sh.siava.pixelxpert.xposed.XposedModPack;
 import sh.siava.pixelxpert.xposed.annotations.LauncherModPack;
 import sh.siava.pixelxpert.xposed.utils.SystemUtils;
-import sh.siava.pixelxpert.xposed.utils.toolkit.ReflectedClass;
+import sh.siava.pixelxpert.xposed.utils.reflection.ReflectedClass;
 
 @LauncherModPack
 public class HideNavigationBarInsets extends XposedModPack {
@@ -33,7 +33,7 @@ public class HideNavigationBarInsets extends XposedModPack {
 
     @SuppressLint("DiscouragedApi")
     @Override
-    public void onPackageLoaded(XC_LoadPackage.LoadPackageParam lpParam) throws Throwable {
+    public void onPackageLoaded(XposedModuleInterface.PackageReadyParam PRParam) throws Throwable {
         ReflectedClass TaskbarActivityContextClass = ReflectedClass.of("com.android.launcher3.taskbar.TaskbarActivityContext");
         TaskbarActivityContextClass
                 .before("notifyUpdateLayoutParams")

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
@@ -18,7 +18,6 @@ import static sh.siava.pixelxpert.xposed.utils.SystemUtils.resourceIdOf;
 import static sh.siava.pixelxpert.xposed.utils.toolkit.ObjectTools.getStateFlowImplOf;
 import static sh.siava.pixelxpert.xposed.utils.reflection.ReflectionTools.reAddView;
 
-import android.animation.LayoutTransition;
 import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
@@ -158,6 +157,7 @@ public class StatusbarMods extends XposedModPack {
 	private static float SBPaddingStart = 0, SBPaddingEnd = 0;
 	private FrameLayout mPhoneStatusbarView;
 	private View mStatusBarContents;
+	private final Runnable mSetHeightsRunnable = this::setHeights;
 
 	//endregion
 
@@ -498,6 +498,7 @@ public class StatusbarMods extends XposedModPack {
 		return Math.min(safeTopInset, maxTopInset);
 	}
 
+	@SuppressLint("DiscouragedApi")
 	private int getAndroidDimensionPixelSize(String resourceName, int defaultValue) {
 		try {
 			int resId = mContext.getResources().getIdentifier(resourceName, "dimen", "android");
@@ -690,7 +691,7 @@ public class StatusbarMods extends XposedModPack {
 					mClockView = mPhoneStatusbarView.findViewById(idOf("clock"));
 					updateClockColor();
 
-					mPhoneStatusbarView.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> setHeights());
+					mPhoneStatusbarView.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> scheduleHeightsUpdate());
 					applyPhoneStatusBarViewHeight();
 
 					mStatusbarStartSide = mPhoneStatusbarView.findViewById(idOf("status_bar_start_side_except_heads_up"));
@@ -719,9 +720,6 @@ public class StatusbarMods extends XposedModPack {
 					}
 
 
-					if (mNotificationIconContainer.getChildCount() == 0) {
-						mNotificationContainerContainer.setVisibility(GONE);
-					}
 					setHeights();
 
 					placeClock();
@@ -852,16 +850,12 @@ public class StatusbarMods extends XposedModPack {
 		}
 
 		mLeftVerticalSplitContainer.setOrientation(VERTICAL);
+		mLeftVerticalSplitContainer.setLayoutTransition(null);
 		LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT);
 		setLeftSplitAreaMargins(lp);
 
 		mLeftVerticalSplitContainer.setLayoutParams(lp);
-		mLeftVerticalSplitContainer.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> setHeights());
-
-		LayoutTransition layoutTransition = new LayoutTransition();
-		layoutTransition.enableTransitionType(LayoutTransition.CHANGING);
-		layoutTransition.setDuration(200);
-		mLeftVerticalSplitContainer.setLayoutTransition(layoutTransition);
+		mLeftVerticalSplitContainer.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> scheduleHeightsUpdate());
 
 		mLeftExtraRowContainer = new ShyLinearLayout(mContext);
 		mLeftExtraRowContainer.setBaselineAligned(false);
@@ -889,16 +883,12 @@ public class StatusbarMods extends XposedModPack {
 		mNotificationIconContainer.setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
 			@Override
 			public void onChildViewAdded(View parent, View child) {
-				mNotificationContainerContainer.setVisibility(VISIBLE);
-				setHeights();
+				scheduleHeightsUpdate();
 			}
 
 			@Override
 			public void onChildViewRemoved(View parent, View child) {
-				if (mNotificationIconContainer.getChildCount() == 0) {
-					mNotificationContainerContainer.setVisibility(GONE);
-					setHeights();
-				}
+				scheduleHeightsUpdate();
 			}
 		});
 
@@ -925,6 +915,12 @@ public class StatusbarMods extends XposedModPack {
 
 
 	private void setHeights() {
+		if (mPhoneStatusbarView == null
+				|| mNotificationContainerContainer == null
+				|| mLeftExtraRowContainer == null
+				|| mNotificationIconContainer == null)
+			return;
+
 		applyPhoneStatusBarViewHeight();
 		int statusbarHeight = getStatusbarContentHeight();
 		if (statusbarHeight <= 0) return;
@@ -933,13 +929,25 @@ public class StatusbarMods extends XposedModPack {
 		setLeftSplitAreaMargins(mLeftVerticalSplitContainer);
 
 		int splitHeight = Math.max(1, statusbarHeight / 2);
+		boolean hasExtraRow = mLeftExtraRowContainer.getVisibility() == VISIBLE;
+		boolean hasNotificationIcons = mNotificationIconContainer.getChildCount() > 0;
 
-		setHeight(mNotificationContainerContainer, (mLeftExtraRowContainer.getVisibility() == VISIBLE) ? splitHeight : MATCH_PARENT);
-		setHeight(mLeftExtraRowContainer, ((mNotificationContainerContainer.getVisibility() == VISIBLE) ? splitHeight : MATCH_PARENT));
+		if (mNotificationContainerContainer.getVisibility() != VISIBLE) {
+			mNotificationContainerContainer.setVisibility(VISIBLE);
+		}
+		setHeight(mNotificationContainerContainer, hasNotificationIcons ? (hasExtraRow ? splitHeight : MATCH_PARENT) : 0);
+		setHeight(mLeftExtraRowContainer, (hasExtraRow && hasNotificationIcons) ? splitHeight : MATCH_PARENT);
 		setHeight(mNotificationIconContainer, MATCH_PARENT);
 		if (networkOnSBEnabled) {
 			setHeight(networkTrafficSB, statusbarHeight / ((networkTrafficPosition == POSITION_LEFT && notificationAreaMultiRow) ? 2 : 1));
 		}
+	}
+
+	private void scheduleHeightsUpdate() {
+		if (mPhoneStatusbarView == null) return;
+
+		mPhoneStatusbarView.removeCallbacks(mSetHeightsRunnable);
+		mPhoneStatusbarView.post(mSetHeightsRunnable);
 	}
 
 	private int getStatusbarContentHeight() {
@@ -1012,6 +1020,7 @@ public class StatusbarMods extends XposedModPack {
 		return height;
 	}
 
+	@SuppressLint("DiscouragedApi")
 	private int getAndroidDimensionPixelSize(Context context, String resourceName, int defaultValue) {
 		try {
 			int resId = context.getResources().getIdentifier(resourceName, "dimen", "android");
@@ -1034,8 +1043,12 @@ public class StatusbarMods extends XposedModPack {
 
 	private void setLeftSplitAreaMargins(View view) {
 		if (view.getLayoutParams() instanceof ViewGroup.MarginLayoutParams layoutParams) {
+			int oldTopMargin = layoutParams.topMargin;
+			int oldBottomMargin = layoutParams.bottomMargin;
 			setLeftSplitAreaMargins(layoutParams);
-			view.setLayoutParams(layoutParams);
+			if (layoutParams.topMargin != oldTopMargin || layoutParams.bottomMargin != oldBottomMargin) {
+				view.setLayoutParams(layoutParams);
+			}
 		}
 	}
 

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
@@ -90,6 +90,8 @@ public class StatusbarMods extends XposedModPack {
 
 	private static final int AM_PM_STYLE_SMALL = 1;
 	private static final int AM_PM_STYLE_GONE = 2;
+	private static final String ORIGINAL_STATUS_BAR_CONTENTS_TOP_PADDING = "px_original_status_bar_contents_top_padding";
+	private static final String ORIGINAL_STATUS_BAR_TRANSLATION_Y = "px_original_status_bar_translation_y";
 	private final int leftClockPadding, rightClockPadding;
 	private static int clockPosition = POSITION_LEFT;
 	private static int mAmPmStyle = AM_PM_STYLE_GONE;
@@ -134,6 +136,8 @@ public class StatusbarMods extends XposedModPack {
 	private static final ArrayList<ClockVisibilityCallback> clockVisibilityCallbacks = new ArrayList<>();
 	private Object mActivityStarter;
 	private static boolean notificationAreaMultiRow = false;
+	private static boolean noCutoutEnabled = false;
+	private static int statusbarHeightFactor = 100;
 	private static int NotificationAODIconLimit = 3;
 	private static int NotificationIconLimit = 4;
 	private Object AODNIC;
@@ -147,11 +151,13 @@ public class StatusbarMods extends XposedModPack {
 
 	private TextView mClockView;
 	private ViewGroup mNotificationIconContainer = null;
+	private ViewGroup mNotificationIconArea = null;
 	LinearLayout mNotificationContainerContainer;
 	private LinearLayout mLeftVerticalSplitContainer;
 	private LinearLayout mLeftExtraRowContainer;
 	private static float SBPaddingStart = 0, SBPaddingEnd = 0;
 	private FrameLayout mPhoneStatusbarView;
+	private View mStatusBarContents;
 
 	//endregion
 
@@ -244,6 +250,8 @@ public class StatusbarMods extends XposedModPack {
 			}
 		}
 		notificationAreaMultiRow = Xprefs.getBoolean("notificationAreaMultiRow", false);
+		noCutoutEnabled = Xprefs.getBoolean("noCutoutEnabled", false);
+		statusbarHeightFactor = Xprefs.getSliderInt("statusbarHeightFactor", 100);
 
 		try {
 			NotificationIconLimit = Integer.parseInt(Xprefs.getString("NotificationIconLimit", "").trim());
@@ -452,6 +460,53 @@ public class StatusbarMods extends XposedModPack {
 		}
 	}
 
+	private void applyStatusBarContentPadding(View sbContentsView) {
+		if (sbContentsView == null) return;
+
+		Object originalTopPadding = getAdditionalInstanceField(sbContentsView, ORIGINAL_STATUS_BAR_CONTENTS_TOP_PADDING);
+		if (!(originalTopPadding instanceof Integer)) {
+			originalTopPadding = sbContentsView.getPaddingTop();
+			setAdditionalInstanceField(sbContentsView, ORIGINAL_STATUS_BAR_CONTENTS_TOP_PADDING, originalTopPadding);
+		}
+
+		int paddingTop = (Integer) originalTopPadding;
+
+		int screenWidth = mContext.getResources().getDisplayMetrics().widthPixels;
+
+		int paddingStart = SBPaddingStart == PADDING_DEFAULT
+				? sbContentsView.getPaddingStart()
+				: Math.round(SBPaddingStart * screenWidth / 100f);
+
+		int paddingEnd = SBPaddingEnd == PADDING_DEFAULT
+				? sbContentsView.getPaddingEnd()
+				: Math.round(SBPaddingEnd * screenWidth / 100f);
+
+		sbContentsView.setPaddingRelative(paddingStart, paddingTop, paddingEnd, sbContentsView.getPaddingBottom());
+	}
+
+	private int getStatusBarContentTopInset() {
+		if (!noCutoutEnabled && !notificationAreaMultiRow) return 0;
+
+		int safeTopInset = ResourceTools.dpToPx(mContext, 6);
+		if (!notificationAreaMultiRow) return safeTopInset;
+
+		int statusbarHeight = getPhoneStatusBarHeight();
+		int iconSize = getAndroidDimensionPixelSize("status_bar_icon_size", ResourceTools.dpToPx(mContext, 22));
+		if (statusbarHeight <= 0 || iconSize <= 0) return safeTopInset;
+
+		int maxTopInset = Math.max(0, statusbarHeight - (2 * iconSize));
+		return Math.min(safeTopInset, maxTopInset);
+	}
+
+	private int getAndroidDimensionPixelSize(String resourceName, int defaultValue) {
+		try {
+			int resId = mContext.getResources().getIdentifier(resourceName, "dimen", "android");
+			return resId == 0 ? defaultValue : mContext.getResources().getDimensionPixelSize(resId);
+		} catch (Throwable ignored) {
+			return defaultValue;
+		}
+	}
+
 	@SuppressLint("DiscouragedApi")
 	@Override
 	public void onPackageLoaded(XposedModuleInterface.PackageReadyParam PRParam) throws Throwable {
@@ -574,21 +629,11 @@ public class StatusbarMods extends XposedModPack {
 				.run(param -> {
 					@SuppressLint("DiscouragedApi")
 					View sbContentsView = ((View) param.thisObject).findViewById(idOf("status_bar_contents"));
+					mStatusBarContents = sbContentsView;
 
-					if (SBPaddingStart == PADDING_DEFAULT && SBPaddingEnd == PADDING_DEFAULT)
-						return;
-
-					int screenWidth = mContext.getResources().getDisplayMetrics().widthPixels;
-
-					int paddingStart = SBPaddingStart == PADDING_DEFAULT
-							? sbContentsView.getPaddingStart()
-							: Math.round(SBPaddingStart * screenWidth / 100f);
-
-					int paddingEnd = SBPaddingEnd == PADDING_DEFAULT
-							? sbContentsView.getPaddingEnd()
-							: Math.round(SBPaddingEnd * screenWidth / 100f);
-
-					sbContentsView.setPaddingRelative(paddingStart, sbContentsView.getPaddingTop(), paddingEnd, sbContentsView.getPaddingBottom());
+					applyPhoneStatusBarViewHeight();
+					applyStatusBarContentPadding(sbContentsView);
+					applyStatusBarContainerLayout();
 				});
 		//endregion
 
@@ -646,8 +691,11 @@ public class StatusbarMods extends XposedModPack {
 					updateClockColor();
 
 					mPhoneStatusbarView.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> setHeights());
+					applyPhoneStatusBarViewHeight();
 
 					mStatusbarStartSide = mPhoneStatusbarView.findViewById(idOf("status_bar_start_side_except_heads_up"));
+					mStatusBarContents = mPhoneStatusbarView.findViewById(idOf("status_bar_contents"));
+					applyStatusBarContentPadding(mStatusBarContents);
 
 					mSystemIconArea = mPhoneStatusbarView.findViewById(idOf("statusIcons"));
 
@@ -677,6 +725,7 @@ public class StatusbarMods extends XposedModPack {
 					setHeights();
 
 					placeClock();
+					setHeights();
 				});
 
 		//clock mods
@@ -789,6 +838,8 @@ public class StatusbarMods extends XposedModPack {
 		mNotificationIconContainer = mPhoneStatusbarView.findViewById(idOf("notificationIcons"));
 
 		mNotificationContainerContainer = new LinearLayout(mContext);
+		mNotificationContainerContainer.setBaselineAligned(false);
+		mNotificationContainerContainer.setGravity(Gravity.CENTER_VERTICAL);
 		mNotificationContainerContainer.setClipChildren(false); //allowing headsup icon to go beyond
 
 		if (mLeftVerticalSplitContainer == null) {
@@ -802,9 +853,7 @@ public class StatusbarMods extends XposedModPack {
 
 		mLeftVerticalSplitContainer.setOrientation(VERTICAL);
 		LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT);
-		int margin = ResourceTools.dpToPx(mContext, 4);
-		lp.topMargin = margin;
-		lp.bottomMargin = margin;
+		setLeftSplitAreaMargins(lp);
 
 		mLeftVerticalSplitContainer.setLayoutParams(lp);
 		mLeftVerticalSplitContainer.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> setHeights());
@@ -815,9 +864,15 @@ public class StatusbarMods extends XposedModPack {
 		mLeftVerticalSplitContainer.setLayoutTransition(layoutTransition);
 
 		mLeftExtraRowContainer = new ShyLinearLayout(mContext);
+		mLeftExtraRowContainer.setBaselineAligned(false);
+		mLeftExtraRowContainer.setGravity(Gravity.CENTER_VERTICAL);
+		mLeftExtraRowContainer.setClipChildren(false);
 		mLeftVerticalSplitContainer.addView(mLeftExtraRowContainer, 0);
 
 		ViewGroup parent = (ViewGroup) mNotificationIconContainer.getParent();
+		mNotificationIconArea = parent;
+		mNotificationIconArea.setClipChildren(false);
+		mNotificationIconArea.setClipToPadding(false);
 
 		parent.addView(mLeftVerticalSplitContainer, parent.indexOfChild(mNotificationIconContainer));
 		parent.removeView(mNotificationIconContainer);
@@ -827,7 +882,10 @@ public class StatusbarMods extends XposedModPack {
 
 		mNotificationContainerContainer.addView(mNotificationIconContainer);
 
-		((LinearLayout.LayoutParams) mNotificationIconContainer.getLayoutParams()).weight = 100;
+		LinearLayout.LayoutParams notificationIconParams = (LinearLayout.LayoutParams) mNotificationIconContainer.getLayoutParams();
+		notificationIconParams.weight = 100;
+		notificationIconParams.gravity = Gravity.CENTER_VERTICAL;
+		mNotificationIconContainer.setLayoutParams(notificationIconParams);
 		mNotificationIconContainer.setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
 			@Override
 			public void onChildViewAdded(View parent, View child) {
@@ -847,6 +905,7 @@ public class StatusbarMods extends XposedModPack {
 		((View) mStatusbarStartSide.getParent()).getLayoutParams().height = MATCH_PARENT;
 		mStatusbarStartSide.getLayoutParams().height = MATCH_PARENT;
 		mLeftVerticalSplitContainer.getLayoutParams().height = MATCH_PARENT;
+		applyStatusBarContainerLayout();
 	}
 
 	private void repositionOngoingChip() {
@@ -866,14 +925,305 @@ public class StatusbarMods extends XposedModPack {
 
 
 	private void setHeights() {
-		@SuppressLint("DiscouragedApi") int statusbarHeight = mPhoneStatusbarView.getLayoutParams().height
-				- mContext.getResources().getDimensionPixelSize(dimenIdOf("status_bar_padding_top"));
+		applyPhoneStatusBarViewHeight();
+		int statusbarHeight = getStatusbarContentHeight();
+		if (statusbarHeight <= 0) return;
 
-		mNotificationContainerContainer.getLayoutParams().height = (mLeftExtraRowContainer.getVisibility() == VISIBLE) ? statusbarHeight / 2 : MATCH_PARENT;
-		mLeftExtraRowContainer.getLayoutParams().height = ((mNotificationContainerContainer.getVisibility() == VISIBLE) ? statusbarHeight / 2 : MATCH_PARENT);
+		applyStatusBarContainerLayout();
+		setLeftSplitAreaMargins(mLeftVerticalSplitContainer);
+
+		int splitHeight = Math.max(1, statusbarHeight / 2);
+
+		setHeight(mNotificationContainerContainer, (mLeftExtraRowContainer.getVisibility() == VISIBLE) ? splitHeight : MATCH_PARENT);
+		setHeight(mLeftExtraRowContainer, ((mNotificationContainerContainer.getVisibility() == VISIBLE) ? splitHeight : MATCH_PARENT));
+		setHeight(mNotificationIconContainer, MATCH_PARENT);
 		if (networkOnSBEnabled) {
-			networkTrafficSB.getLayoutParams().height = statusbarHeight / ((networkTrafficPosition == POSITION_LEFT && notificationAreaMultiRow) ? 2 : 1);
+			setHeight(networkTrafficSB, statusbarHeight / ((networkTrafficPosition == POSITION_LEFT && notificationAreaMultiRow) ? 2 : 1));
 		}
+	}
+
+	private int getStatusbarContentHeight() {
+		return Math.max(0, getPhoneStatusBarHeight() - getStatusBarContentTopInset());
+	}
+
+	private int getPhoneStatusBarHeight() {
+		int insetsHeight = getStatusBarInsetsHeight();
+		if (insetsHeight > 0) {
+			return insetsHeight;
+		}
+
+		int targetHeight = getTargetPhoneStatusBarHeight();
+		if (targetHeight > 0) {
+			return targetHeight;
+		}
+
+		int statusbarHeight = 0;
+		if (statusbarHeight <= 0) {
+			statusbarHeight = getViewHeight(mPhoneStatusbarView);
+		}
+		if (statusbarHeight <= 0) {
+			statusbarHeight = getViewHeight(mStatusBarContents);
+		}
+		return statusbarHeight;
+	}
+
+	private int getStatusBarInsetsHeight() {
+		try {
+			if (mPhoneStatusbarView == null || mPhoneStatusbarView.getRootWindowInsets() == null) return 0;
+
+			return mPhoneStatusbarView
+					.getRootWindowInsets()
+					.getInsetsIgnoringVisibility(android.view.WindowInsets.Type.statusBars())
+					.top;
+		} catch (Throwable ignored) {
+			return 0;
+		}
+	}
+
+	private int getTargetPhoneStatusBarHeight() {
+		try {
+			Context portraitContext = getPortraitContext();
+			int height = getAndroidDimensionPixelSize(
+					portraitContext,
+					"status_bar_height_portrait",
+					getAndroidDimensionPixelSize(portraitContext, "status_bar_height", 0));
+			return Math.round(height * statusbarHeightFactor / 100f);
+		} catch (Throwable ignored) {
+			return 0;
+		}
+	}
+
+	private Context getPortraitContext() {
+		android.content.res.Configuration config = new android.content.res.Configuration(mContext.getResources().getConfiguration());
+		config.orientation = android.content.res.Configuration.ORIENTATION_PORTRAIT;
+		return mContext.createConfigurationContext(config);
+	}
+
+	private int getViewHeight(View view) {
+		if (view == null) return 0;
+
+		int height = view.getHeight();
+		if (height <= 0) {
+			height = view.getMeasuredHeight();
+		}
+		if (height <= 0 && view.getLayoutParams() != null && view.getLayoutParams().height > 0) {
+			height = view.getLayoutParams().height;
+		}
+		return height;
+	}
+
+	private int getAndroidDimensionPixelSize(Context context, String resourceName, int defaultValue) {
+		try {
+			int resId = context.getResources().getIdentifier(resourceName, "dimen", "android");
+			return resId == 0 ? defaultValue : context.getResources().getDimensionPixelSize(resId);
+		} catch (Throwable ignored) {
+			return defaultValue;
+		}
+	}
+
+	private void setLeftSplitAreaMargins(ViewGroup.MarginLayoutParams layoutParams) {
+		if (notificationAreaMultiRow) {
+			layoutParams.topMargin = 0;
+			layoutParams.bottomMargin = 0;
+		} else {
+			int margin = ResourceTools.dpToPx(mContext, 4);
+			layoutParams.topMargin = margin;
+			layoutParams.bottomMargin = margin;
+		}
+	}
+
+	private void setLeftSplitAreaMargins(View view) {
+		if (view.getLayoutParams() instanceof ViewGroup.MarginLayoutParams layoutParams) {
+			setLeftSplitAreaMargins(layoutParams);
+			view.setLayoutParams(layoutParams);
+		}
+	}
+
+	private void setHeight(View view, int height) {
+		if (view == null) return;
+
+		ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
+		if (layoutParams != null && layoutParams.height != height) {
+			layoutParams.height = height;
+			view.setLayoutParams(layoutParams);
+		}
+	}
+
+	private void applyStatusBarContainerLayout() {
+		int topInset = getStatusBarContentTopInset();
+		int contentHeight = getStatusbarContentHeight();
+
+		applyPhoneStatusBarViewHeight();
+		applyMatchParentHeight(mStatusBarContents);
+		applyMatchParentHeight(mStatusbarStartSide);
+		applyMatchParentHeight(mNotificationIconArea);
+		if (mStatusbarStartSide != null && mStatusbarStartSide.getParent() instanceof View) {
+			applyMatchParentHeight((View) mStatusbarStartSide.getParent());
+		}
+
+		applyVerticalContentBounds(mCenteredIconArea, 0, contentHeight);
+		applyStatusBarTranslationY(mCenteredIconArea, getSingleRowStatusBarTranslationY(mCenteredIconArea));
+		if (mSystemIconArea != null) {
+			if (mSystemIconArea.getParent() instanceof View) {
+				View systemIconParent = (View) mSystemIconArea.getParent();
+				applyVerticalContentBounds(systemIconParent, 0, contentHeight);
+				applyStatusBarTranslationY(systemIconParent, getSingleRowStatusBarTranslationY(systemIconParent));
+				applyContentChildBounds(mSystemIconArea);
+				applyStatusBarTranslationY(mSystemIconArea, 0);
+			} else {
+				applyVerticalContentBounds(mSystemIconArea, 0, contentHeight);
+				applyStatusBarTranslationY(mSystemIconArea, getSingleRowStatusBarTranslationY(mSystemIconArea));
+			}
+		}
+		if (mLeftVerticalSplitContainer != null) {
+			applyStatusBarTranslationY(mLeftVerticalSplitContainer, notificationAreaMultiRow
+					? topInset
+					: getSingleRowStatusBarTranslationY(mLeftVerticalSplitContainer));
+		}
+		applyLinearLayoutGravity(mLeftExtraRowContainer, Gravity.CENTER_VERTICAL);
+		applyLinearLayoutGravity(mNotificationContainerContainer, Gravity.CENTER_VERTICAL);
+		applyLinearLayoutGravity(mSystemIconArea, Gravity.CENTER_VERTICAL);
+
+		if (mClockView != null) {
+			mClockView.setGravity(Gravity.CENTER_VERTICAL);
+			applyLayoutGravity(mClockView, Gravity.CENTER_VERTICAL);
+		}
+	}
+
+	private float getSingleRowStatusBarTranslationY(View view) {
+		if (view == null) return 0;
+
+		int statusbarHeight = getPhoneStatusBarHeight();
+		int contentHeight = Math.max(0, statusbarHeight - getStatusBarContentTopInset());
+		int viewHeight = getViewHeight(view);
+		if (contentHeight <= 0 || viewHeight <= 0) return getStatusBarContentTopInset();
+
+		return getStatusBarContentTopInset() + Math.max(0, (contentHeight - viewHeight) / 2f);
+	}
+
+	private void applyStatusBarTranslationY(View view, float translationY) {
+		if (view == null) return;
+
+		Object originalTranslationY = getAdditionalInstanceField(view, ORIGINAL_STATUS_BAR_TRANSLATION_Y);
+		if (!(originalTranslationY instanceof Float)) {
+			originalTranslationY = view.getTranslationY();
+			setAdditionalInstanceField(view, ORIGINAL_STATUS_BAR_TRANSLATION_Y, originalTranslationY);
+		}
+		view.setTranslationY((Float) originalTranslationY + translationY);
+	}
+
+	private void applyMatchParentHeight(View view) {
+		if (view == null || view.getLayoutParams() == null) return;
+
+		ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
+		if (layoutParams.height != MATCH_PARENT) {
+			layoutParams.height = MATCH_PARENT;
+			view.setLayoutParams(layoutParams);
+		}
+		if (view instanceof ViewGroup viewGroup) {
+			viewGroup.setClipChildren(false);
+			viewGroup.setClipToPadding(false);
+		}
+	}
+
+	private void applyPhoneStatusBarViewHeight() {
+		int targetHeight = getPhoneStatusBarHeight();
+		if (mPhoneStatusbarView == null || targetHeight <= 0) return;
+
+		ViewGroup.LayoutParams layoutParams = mPhoneStatusbarView.getLayoutParams();
+		if (layoutParams != null && layoutParams.height != targetHeight) {
+			layoutParams.height = targetHeight;
+			mPhoneStatusbarView.setLayoutParams(layoutParams);
+			mPhoneStatusbarView.requestLayout();
+		}
+	}
+
+	private void applyVerticalContentBounds(View view, int topMargin, int height) {
+		if (view == null || view.getLayoutParams() == null || height <= 0) return;
+
+		ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
+		boolean changed = false;
+		if (layoutParams.height != height) {
+			layoutParams.height = height;
+			changed = true;
+		}
+		if (layoutParams instanceof ViewGroup.MarginLayoutParams marginLayoutParams) {
+			if (marginLayoutParams.topMargin != topMargin) {
+				marginLayoutParams.topMargin = topMargin;
+				changed = true;
+			}
+			if (marginLayoutParams.bottomMargin != 0) {
+				marginLayoutParams.bottomMargin = 0;
+				changed = true;
+			}
+		}
+		if (changed) {
+			view.setLayoutParams(layoutParams);
+		}
+		applyLayoutGravity(view, Gravity.CENTER_VERTICAL);
+		if (view instanceof ViewGroup viewGroup) {
+			viewGroup.setClipChildren(false);
+			viewGroup.setClipToPadding(false);
+		}
+	}
+
+	private void applyContentChildBounds(View view) {
+		if (view == null || view.getLayoutParams() == null) return;
+
+		ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
+		boolean changed = false;
+		if (layoutParams.height != MATCH_PARENT) {
+			layoutParams.height = MATCH_PARENT;
+			changed = true;
+		}
+		if (layoutParams instanceof ViewGroup.MarginLayoutParams marginLayoutParams) {
+			if (marginLayoutParams.topMargin != 0) {
+				marginLayoutParams.topMargin = 0;
+				changed = true;
+			}
+			if (marginLayoutParams.bottomMargin != 0) {
+				marginLayoutParams.bottomMargin = 0;
+				changed = true;
+			}
+		}
+		if (changed) {
+			view.setLayoutParams(layoutParams);
+		}
+		applyLayoutGravity(view, Gravity.CENTER_VERTICAL);
+	}
+
+	private void applyLayoutGravity(View view, int gravity) {
+		if (view == null || view.getLayoutParams() == null) return;
+
+		ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
+		if (layoutParams instanceof LinearLayout.LayoutParams linearLayoutParams) {
+			int updatedGravity = mergeVerticalGravity(linearLayoutParams.gravity, gravity);
+			if (linearLayoutParams.gravity != updatedGravity) {
+				linearLayoutParams.gravity = updatedGravity;
+				view.setLayoutParams(linearLayoutParams);
+			}
+		} else if (layoutParams instanceof FrameLayout.LayoutParams frameLayoutParams) {
+			int updatedGravity = mergeVerticalGravity(frameLayoutParams.gravity, gravity);
+			if (frameLayoutParams.gravity != updatedGravity) {
+				frameLayoutParams.gravity = updatedGravity;
+				view.setLayoutParams(frameLayoutParams);
+			}
+		}
+	}
+
+	private void applyLinearLayoutGravity(LinearLayout view, int gravity) {
+		if (view == null) return;
+
+		int updatedGravity = mergeVerticalGravity(view.getGravity(), gravity);
+		if (view.getGravity() != updatedGravity) {
+			view.setGravity(updatedGravity);
+		}
+	}
+
+	private int mergeVerticalGravity(int originalGravity, int verticalGravity) {
+		if (originalGravity < 0) originalGravity = 0;
+
+		return (originalGravity & ~Gravity.VERTICAL_GRAVITY_MASK) | verticalGravity;
 	}
 	//endregion
 

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
@@ -41,6 +41,7 @@ import android.text.style.RelativeSizeSpan;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -90,7 +91,6 @@ public class StatusbarMods extends XposedModPack {
 	private static final int AM_PM_STYLE_SMALL = 1;
 	private static final int AM_PM_STYLE_GONE = 2;
 	private static final String ORIGINAL_STATUS_BAR_CONTENTS_TOP_PADDING = "px_original_status_bar_contents_top_padding";
-	private static final String ORIGINAL_STATUS_BAR_TRANSLATION_Y = "px_original_status_bar_translation_y";
 	private final int leftClockPadding, rightClockPadding;
 	private static int clockPosition = POSITION_LEFT;
 	private static int mAmPmStyle = AM_PM_STYLE_GONE;
@@ -426,6 +426,9 @@ public class StatusbarMods extends XposedModPack {
 				case "statusbarPaddings":
 					updateStatusbarHeight();
 					break;
+				case "NotificationIconLimit":
+					applyNotificationIconLimit();
+					break;
 				case "VolteIconEnabled":
 				case "VowifiIconEnabled":
 					if (VolteIconEnabled || VowifiIconEnabled) {
@@ -485,17 +488,31 @@ public class StatusbarMods extends XposedModPack {
 	}
 
 	private int getStatusBarContentTopInset() {
-		if (!noCutoutEnabled && !notificationAreaMultiRow) return 0;
+		if (!noCutoutEnabled) return 0;
+		if (notificationAreaMultiRow) return 0;
 
-		int safeTopInset = ResourceTools.dpToPx(mContext, 6);
-		if (!notificationAreaMultiRow) return safeTopInset;
+		return ResourceTools.dpToPx(mContext, 6);
+	}
 
-		int statusbarHeight = getPhoneStatusBarHeight();
-		int iconSize = getAndroidDimensionPixelSize("status_bar_icon_size", ResourceTools.dpToPx(mContext, 22));
-		if (statusbarHeight <= 0 || iconSize <= 0) return safeTopInset;
+	private int getStatusBarIconRowHeight() {
+		return getAndroidDimensionPixelSize("status_bar_icon_size_sp",
+				getAndroidDimensionPixelSize("status_bar_icon_size", ResourceTools.dpToPx(mContext, 22)));
+	}
 
-		int maxTopInset = Math.max(0, statusbarHeight - (2 * iconSize));
-		return Math.min(safeTopInset, maxTopInset);
+	private int getStatusBarIconSlotWidth() {
+		int iconSize = getStatusBarIconRowHeight();
+		int horizontalMargin = getSystemUiDimensionPixelSize("status_bar_icon_horizontal_margin", 0);
+		return iconSize + (2 * horizontalMargin);
+	}
+
+	@SuppressLint("DiscouragedApi")
+	private int getSystemUiDimensionPixelSize(String resourceName, int defaultValue) {
+		try {
+			int resId = dimenIdOf(resourceName);
+			return resId == 0 ? defaultValue : mContext.getResources().getDimensionPixelSize(resId);
+		} catch (Throwable ignored) {
+			return defaultValue;
+		}
 	}
 
 	@SuppressLint("DiscouragedApi")
@@ -620,33 +637,76 @@ public class StatusbarMods extends XposedModPack {
 				});
 		//endregion
 
-		//region SB Padding
-		PhoneStatusBarViewClass
-				.afterConstruction()
-				.run(param -> mPhoneStatusbarView = (FrameLayout) param.thisObject);
+			//region SB Padding
+			PhoneStatusBarViewClass
+					.afterConstruction()
+					.run(param -> mPhoneStatusbarView = (FrameLayout) param.thisObject);
 
-		PhoneStatusBarViewClass
-				.after("updateStatusBarHeight")
-				.run(param -> {
+			PhoneStatusBarViewClass
+					.after("onFinishInflate")
+					.run(param -> {
+						mPhoneStatusbarView = (FrameLayout) param.thisObject;
+						scheduleHeightsUpdate();
+					});
+
+			PhoneStatusBarViewClass
+					.after("onAttachedToWindow")
+					.run(param -> {
+						mPhoneStatusbarView = (FrameLayout) param.thisObject;
+						scheduleHeightsUpdate();
+					});
+
+			PhoneStatusBarViewClass
+					.after("updateStatusBarHeight")
+					.run(param -> {
 					@SuppressLint("DiscouragedApi")
 					View sbContentsView = ((View) param.thisObject).findViewById(idOf("status_bar_contents"));
 					mStatusBarContents = sbContentsView;
 
-					applyPhoneStatusBarViewHeight();
-					applyStatusBarContentPadding(sbContentsView);
-					applyStatusBarContainerLayout();
-				});
+						applyPhoneStatusBarViewHeight();
+						applyStatusBarContentPadding(sbContentsView);
+						applyStatusBarContainerLayout();
+					});
 		//endregion
 
 		//region multi row statusbar
 		//bypassing the max icon limit during measurement
-		NotificationIconContainerClass
-				.before("onMeasure")
-				.run(param -> setObjectField(param.thisObject, "mIsStaticLayout", false));
+			NotificationIconContainerClass
+					.before("onMeasure")
+					.run(param -> {
+						if (param.thisObject == mNotificationIconContainer) {
+							setObjectField(param.thisObject, "mMaxIcons", NotificationIconLimit);
+						}
+						setObjectField(param.thisObject, "mIsStaticLayout", false);
+					});
+
+			NotificationIconContainerClass
+					.after("onMeasure")
+					.run(param -> {
+						setObjectField(param.thisObject, "mIsStaticLayout", true);
+						if (param.thisObject == mNotificationIconContainer) {
+							applyNotificationIconLayoutWidth();
+						} else if (((View) param.thisObject).getId() == idOf("notificationIcons")) {
+							mNotificationIconContainer = (ViewGroup) param.thisObject;
+						}
+					});
 
 		NotificationIconContainerClass
-				.after("onMeasure")
-				.run(param -> setObjectField(param.thisObject, "mIsStaticLayout", true));
+				.before("setMaxIconsAmount")
+				.run(param -> {
+					if (param.thisObject == mNotificationIconContainer && param.args.length > 0) {
+						param.args[0] = NotificationIconLimit;
+					}
+				});
+
+			NotificationIconContainerClass
+					.after("setMaxIconsAmount")
+					.run(param -> {
+						if (param.thisObject == mNotificationIconContainer) {
+							applyNotificationIconLayoutWidth();
+							scheduleHeightsUpdate();
+						}
+					});
 
 		//endregion
 
@@ -720,11 +780,11 @@ public class StatusbarMods extends XposedModPack {
 					}
 
 
-					setHeights();
+						setHeights();
 
-					placeClock();
-					setHeights();
-				});
+						placeClock();
+						setHeights();
+					});
 
 		//clock mods
 		ClockClass
@@ -830,6 +890,17 @@ public class StatusbarMods extends XposedModPack {
 		}
 	}
 
+	private void applyNotificationIconLimit() {
+		if (mNotificationIconContainer == null) return;
+
+		try {
+			callMethod(mNotificationIconContainer, "setMaxIconsAmount", NotificationIconLimit);
+			applyNotificationIconLayoutWidth();
+			scheduleHeightsUpdate();
+		} catch (Throwable ignored) {
+		}
+	}
+
 	//region double row left area
 	@SuppressLint("DiscouragedApi")
 	private void makeLeftSplitArea() {
@@ -880,6 +951,7 @@ public class StatusbarMods extends XposedModPack {
 		notificationIconParams.weight = 100;
 		notificationIconParams.gravity = Gravity.CENTER_VERTICAL;
 		mNotificationIconContainer.setLayoutParams(notificationIconParams);
+		applyNotificationIconLimit();
 		mNotificationIconContainer.setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
 			@Override
 			public void onChildViewAdded(View parent, View child) {
@@ -930,17 +1002,54 @@ public class StatusbarMods extends XposedModPack {
 
 		int splitHeight = Math.max(1, statusbarHeight / 2);
 		boolean hasExtraRow = mLeftExtraRowContainer.getVisibility() == VISIBLE;
-		boolean hasNotificationIcons = mNotificationIconContainer.getChildCount() > 0;
 
 		if (mNotificationContainerContainer.getVisibility() != VISIBLE) {
 			mNotificationContainerContainer.setVisibility(VISIBLE);
 		}
-		setHeight(mNotificationContainerContainer, hasNotificationIcons ? (hasExtraRow ? splitHeight : MATCH_PARENT) : 0);
-		setHeight(mLeftExtraRowContainer, (hasExtraRow && hasNotificationIcons) ? splitHeight : MATCH_PARENT);
+		setHeight(mNotificationContainerContainer, hasExtraRow ? splitHeight : MATCH_PARENT);
+		setHeight(mLeftExtraRowContainer, hasExtraRow ? splitHeight : MATCH_PARENT);
 		setHeight(mNotificationIconContainer, MATCH_PARENT);
+		applyNotificationIconLayoutWidth();
 		if (networkOnSBEnabled) {
 			setHeight(networkTrafficSB, statusbarHeight / ((networkTrafficPosition == POSITION_LEFT && notificationAreaMultiRow) ? 2 : 1));
 		}
+	}
+
+	private void applyNotificationIconLayoutWidth() {
+		if (!notificationAreaMultiRow || mNotificationIconContainer == null) return;
+
+		int desiredWidth = getDesiredNotificationIconLayoutWidth();
+		if (desiredWidth <= 0) return;
+
+		try {
+			Object currentWidth = getObjectField(mNotificationIconContainer, "mActualLayoutWidth");
+			if (currentWidth instanceof Integer && (Integer) currentWidth == desiredWidth) return;
+
+			callMethod(mNotificationIconContainer, "setActualLayoutWidth", desiredWidth);
+			mNotificationIconContainer.requestLayout();
+			mNotificationIconContainer.invalidate();
+		} catch (Throwable ignored) {
+		}
+	}
+
+	private int getDesiredNotificationIconLayoutWidth() {
+		if (mNotificationIconContainer == null) return 0;
+
+		int childCount = mNotificationIconContainer.getChildCount();
+		if (childCount <= 0 || NotificationIconLimit <= 0) return 0;
+
+		int iconSlots = Math.min(childCount, NotificationIconLimit + 1);
+		try {
+			Object calculatedWidth = callMethod(mNotificationIconContainer, "calculateWidthFor", (float) iconSlots);
+			if (calculatedWidth instanceof Number) {
+				int width = (int) Math.ceil(((Number) calculatedWidth).doubleValue());
+				if (width > 0) return width;
+			}
+		} catch (Throwable ignored) {
+		}
+
+		int slotWidth = getStatusBarIconSlotWidth();
+		return slotWidth <= 0 ? 0 : iconSlots * slotWidth;
 	}
 
 	private void scheduleHeightsUpdate() {
@@ -951,28 +1060,14 @@ public class StatusbarMods extends XposedModPack {
 	}
 
 	private int getStatusbarContentHeight() {
-		return Math.max(0, getPhoneStatusBarHeight() - getStatusBarContentTopInset());
+		return Math.max(0, getPhoneStatusBarHeight() - getStatusBarContentsTopPadding() - getStatusBarContentTopInset());
 	}
 
 	private int getPhoneStatusBarHeight() {
-		int insetsHeight = getStatusBarInsetsHeight();
-		if (insetsHeight > 0) {
-			return insetsHeight;
-		}
-
-		int targetHeight = getTargetPhoneStatusBarHeight();
-		if (targetHeight > 0) {
-			return targetHeight;
-		}
-
-		int statusbarHeight = 0;
-		if (statusbarHeight <= 0) {
-			statusbarHeight = getViewHeight(mPhoneStatusbarView);
-		}
-		if (statusbarHeight <= 0) {
-			statusbarHeight = getViewHeight(mStatusBarContents);
-		}
-		return statusbarHeight;
+		int height = Math.max(getTargetPhoneStatusBarHeight(), getStatusBarInsetsHeight());
+		height = Math.max(height, getViewHeight(mPhoneStatusbarView));
+		height = Math.max(height, getViewHeight(mStatusBarContents));
+		return height;
 	}
 
 	private int getStatusBarInsetsHeight() {
@@ -1018,6 +1113,22 @@ public class StatusbarMods extends XposedModPack {
 			height = view.getLayoutParams().height;
 		}
 		return height;
+	}
+
+	private int getStatusBarContentsTopPadding() {
+		if (mStatusBarContents != null) {
+			Object originalTopPadding = getAdditionalInstanceField(mStatusBarContents, ORIGINAL_STATUS_BAR_CONTENTS_TOP_PADDING);
+			if (originalTopPadding instanceof Integer) {
+				return (Integer) originalTopPadding;
+			}
+			return mStatusBarContents.getPaddingTop();
+		}
+
+		try {
+			return mContext.getResources().getDimensionPixelSize(dimenIdOf("status_bar_padding_top"));
+		} catch (Throwable ignored) {
+			return 0;
+		}
 	}
 
 	@SuppressLint("DiscouragedApi")
@@ -1075,21 +1186,21 @@ public class StatusbarMods extends XposedModPack {
 		}
 
 		applyVerticalContentBounds(mCenteredIconArea, 0, contentHeight);
-		applyStatusBarTranslationY(mCenteredIconArea, getSingleRowStatusBarTranslationY(mCenteredIconArea));
+		setStatusBarTranslationY(mCenteredIconArea, getSingleRowStatusBarTranslationY(mCenteredIconArea));
 		if (mSystemIconArea != null) {
 			if (mSystemIconArea.getParent() instanceof View) {
 				View systemIconParent = (View) mSystemIconArea.getParent();
 				applyVerticalContentBounds(systemIconParent, 0, contentHeight);
-				applyStatusBarTranslationY(systemIconParent, getSingleRowStatusBarTranslationY(systemIconParent));
+				setStatusBarTranslationY(systemIconParent, getSingleRowStatusBarTranslationY(systemIconParent));
 				applyContentChildBounds(mSystemIconArea);
-				applyStatusBarTranslationY(mSystemIconArea, 0);
+				setStatusBarTranslationY(mSystemIconArea, 0);
 			} else {
 				applyVerticalContentBounds(mSystemIconArea, 0, contentHeight);
-				applyStatusBarTranslationY(mSystemIconArea, getSingleRowStatusBarTranslationY(mSystemIconArea));
+				setStatusBarTranslationY(mSystemIconArea, getSingleRowStatusBarTranslationY(mSystemIconArea));
 			}
 		}
 		if (mLeftVerticalSplitContainer != null) {
-			applyStatusBarTranslationY(mLeftVerticalSplitContainer, notificationAreaMultiRow
+			setStatusBarTranslationY(mLeftVerticalSplitContainer, notificationAreaMultiRow
 					? topInset
 					: getSingleRowStatusBarTranslationY(mLeftVerticalSplitContainer));
 		}
@@ -1106,23 +1217,19 @@ public class StatusbarMods extends XposedModPack {
 	private float getSingleRowStatusBarTranslationY(View view) {
 		if (view == null) return 0;
 
-		int statusbarHeight = getPhoneStatusBarHeight();
-		int contentHeight = Math.max(0, statusbarHeight - getStatusBarContentTopInset());
+		int contentHeight = getStatusbarContentHeight();
 		int viewHeight = getViewHeight(view);
 		if (contentHeight <= 0 || viewHeight <= 0) return getStatusBarContentTopInset();
 
 		return getStatusBarContentTopInset() + Math.max(0, (contentHeight - viewHeight) / 2f);
 	}
 
-	private void applyStatusBarTranslationY(View view, float translationY) {
+	private void setStatusBarTranslationY(View view, float translationY) {
 		if (view == null) return;
 
-		Object originalTranslationY = getAdditionalInstanceField(view, ORIGINAL_STATUS_BAR_TRANSLATION_Y);
-		if (!(originalTranslationY instanceof Float)) {
-			originalTranslationY = view.getTranslationY();
-			setAdditionalInstanceField(view, ORIGINAL_STATUS_BAR_TRANSLATION_Y, originalTranslationY);
+		if (view.getTranslationY() != translationY) {
+			view.setTranslationY(translationY);
 		}
-		view.setTranslationY((Float) originalTranslationY + translationY);
 	}
 
 	private void applyMatchParentHeight(View view) {
@@ -1143,11 +1250,31 @@ public class StatusbarMods extends XposedModPack {
 		int targetHeight = getPhoneStatusBarHeight();
 		if (mPhoneStatusbarView == null || targetHeight <= 0) return;
 
-		ViewGroup.LayoutParams layoutParams = mPhoneStatusbarView.getLayoutParams();
+		applyStatusBarHeight(mPhoneStatusbarView, targetHeight);
+		applyStatusBarAncestorHeights(targetHeight);
+	}
+
+	private void applyStatusBarAncestorHeights(int targetHeight) {
+		View rootView = mPhoneStatusbarView.getRootView();
+		ViewParent parent = mPhoneStatusbarView.getParent();
+		while (parent instanceof View parentView && parentView != rootView) {
+			if (parentView.getHeight() > 0 && parentView.getHeight() < targetHeight) {
+				applyStatusBarHeight(parentView, targetHeight);
+			}
+			if (parentView instanceof ViewGroup viewGroup) {
+				viewGroup.setClipChildren(false);
+				viewGroup.setClipToPadding(false);
+			}
+			parent = parentView.getParent();
+		}
+	}
+
+	private void applyStatusBarHeight(View view, int targetHeight) {
+		ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
 		if (layoutParams != null && layoutParams.height != targetHeight) {
 			layoutParams.height = targetHeight;
-			mPhoneStatusbarView.setLayoutParams(layoutParams);
-			mPhoneStatusbarView.requestLayout();
+			view.setLayoutParams(layoutParams);
+			view.requestLayout();
 		}
 	}
 

--- a/app/src/main/res/values/xp_module_scope.xml
+++ b/app/src/main/res/values/xp_module_scope.xml
@@ -4,6 +4,7 @@
         <item>com.android.systemui</item> <!-- systemUI -->
         <item>com.google.android.apps.nexuslauncher</item> <!-- Pixel Launcher - Taskbar -->
         <item>android</item>  <!-- System Framework -->
+        <item>system</item>  <!-- system_server on Vector -->
         <item>com.android.settings</item> <!-- settings app -->
         <item>com.google.android.dialer</item> <!-- google dialer -->
         <item>me.weishu.kernelsu</item> <!-- KSU Manager -->

--- a/app/src/main/resources/META-INF/xposed/scope.list
+++ b/app/src/main/resources/META-INF/xposed/scope.list
@@ -1,6 +1,7 @@
 com.android.systemui
 com.google.android.apps.nexuslauncher
 android
+system
 com.android.settings
 com.google.android.dialer
 me.weishu.kernelsu


### PR DESCRIPTION
## Summary

- load PixelXpert in the `system` process so early system-server hooks run on devices that use that process name
- install the no-cutout hook during system-server startup, before WindowManager snapshots the display cutout
- keep SystemUI status bar window height, layout params, rotation params, and provided inset sources synchronized with the configured status bar height
- resize/reposition SystemUI status bar content containers so clock, notification icons, and system icons fit inside the resized no-cutout status bar
- keep resized status bar content visible when fullscreen apps shrink the live `PhoneStatusBarView`/ancestor container back to the stock one-row height
- stabilize the multi-row notification icon area by keeping its wrapper layout-stable, deferring height recalculation out of hierarchy/layout callbacks, removing the extra layout transition around SystemUI's own icon animations, and giving the reparented rows explicit full-width layout params
- update `HideNavigationBarInsets` to the current libxposed `PackageReadyParam` / `ReflectedClass` APIs so canary builds

## Root cause

On affected devices the no-cutout/status-bar-height hooks were applied too late or only partially. WindowManager could expose the larger status bar inset while SystemUI still laid out parts of the visible status bar content with the old content height, leaving the clock and icons cropped.

The framework/window height fix is not sufficient by itself: the SystemUI status bar content tree also needs to be expanded and vertically positioned against the resized status bar. Fullscreen/immersive apps can also make SystemUI shrink the live status bar view hierarchy back to the stock height, so the module now derives content height from the configured target, inset height, and current measured views, then expands shorter status-bar ancestors and disables ancestor clipping.

The notification icon area also had two fragile layout behaviors. First, it used a child-count-based wrapper visibility/height path even though SystemUI can transiently remove and re-add notification icon views during updates or animations. Second, after reparenting, the split rows could inherit wrap-content width, so `NotificationIconContainer` could calculate overflow from a too-small measured width and hide valid icons. The wrapper now stays visible, height splitting no longer depends on transient notification child count, the split rows are full width, and `notificationIcons` consumes the available row width via `width=0` plus weight.

## Validation

- `git diff --check`
- `bash gradlew --no-daemon :app:assembleDebug`
- Built a source-equivalent APK for the affected Pixel 9 and installed it locally before the PR update.
- Manual device observation after the approved reboot: clock and status bar icons no longer appeared cropped, and the result looked stable enough to update this draft PR.

## Notes

This PR remains draft because the affected behavior is SystemUI timing-sensitive and should get more soak time before being marked ready.
