### PR TITLE
Fix: catch NoSuchFieldError in setHooks for Android 17 QPR1 Beta 3+

### DIFF
--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/ScreenGestures.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/ScreenGestures.java
@@ -191,6 +191,7 @@ public class ScreenGestures extends XposedModPack {
 	}
 
 	private void setHooks(HookHelper.RunParam param) {
+		try {
 		Object mPulsingWakeupGestureHandler = getObjectField(param.thisObject, "mPulsingWakeupGestureHandler");//A13 R18
 
 		Object mListener = getObjectField(mPulsingWakeupGestureHandler, "mListener");
@@ -275,6 +276,9 @@ public class ScreenGestures extends XposedModPack {
 						turnOffTTT();
 					}
 				});
+		} catch (Throwable ignored) {
+			// mPulsingWakeupGestureHandler removed in Android 17 QPR1 Beta 3+ (CP31.260508.005)
+		}
 	}
 
 	private boolean isQSExpanded() {


### PR DESCRIPTION
 ### Problem                                                                                          
  `setHooks()` is called unconditionally every time SystemUI starts (via a delayed thread after        
  `NotificationShadeWindowViewController` construction). The field `mPulsingWakeupGestureHandler`      
  does not exist in Android 17 QPR1 Beta 3 (build CP31.260508.005), causing an immediate               
  `NoSuchFieldError` that kills SystemUI.                                                              
                                                                                                       
  SystemUI then restarts and triggers the hook again, crashing repeatedly until PixelXpert's
  bootloop protection kicks in and stops injecting — at which point SystemUI stabilizes but
  all SystemUI hooks are silently inactive.                       
                                                                  
  This happens regardless of which features the user has enabled. Even with zero ScreenGestures        
  options turned on, simply having SystemUI in scope is enough to trigger the crash.                   
                                                                                                       
  The standard workaround of disabling the SystemUI scope in LSPosed before a system update,           
  then re-enabling afterward, prevents the crash — but relies on the user remembering to do so         
  manually every time. Flashing the full system image does not help, as the field is genuinely         
  absent from this build.                                                            
                                                                             
  ### Crash log
  FATAL EXCEPTION: Thread-20                                                                           
  Process: com.android.systemui           
  java.lang.NoSuchFieldError:                                                                          
  com.android.systemui.shade.NotificationShadeWindowViewController#mPulsingWakeupGestureHandler        
      at XposedHelpers.getObjectField(...)                                                     
      at sh.siava.pixelxpert.xposed.modpacks.systemui.ScreenGestures.setHooks(ScreenGestures.java:194) 
      at sh.siava.pixelxpert.xposed.modpacks.systemui.ScreenGestures.lambda$onPackageLoaded$4(ScreenGes
  tures.java:169)                                                                                      
      at java.lang.Thread.run(Thread.java:1572)                                                        
                                                                                                       
  ### Fix                                                                                              
  Wrap the body of `setHooks()` in `try-catch (Throwable)`. Builds where the field exists behave       
  identically to before. Builds where it has been removed skip these secondary gesture hooks silently  
  instead of crashing.                                                                                 
                                                                  
  ### Tested on                                                                                        
  - Pixel 10 Pro XL · Android 17 QPR1 Beta 3 · CP31.260508.005 · KernelSU + LSPosed · canary-494