### PR TITLE
Fix: disable ScreenshotManager hooks on Android 17 (SDK 37+) to prevent screenshot crash

### DIFF
--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/HideNavigationBarInsets.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/HideNavigationBarInsets.java
@@ -9,11 +9,11 @@ import android.view.WindowManager;
 import java.lang.reflect.Array;
 
 import de.robv.android.xposed.XposedHelpers;
-import de.robv.android.xposed.callbacks.XC_LoadPackage;
+
 import sh.siava.pixelxpert.xposed.XposedModPack;
 import sh.siava.pixelxpert.xposed.annotations.LauncherModPack;
 import sh.siava.pixelxpert.xposed.utils.SystemUtils;
-import sh.siava.pixelxpert.xposed.utils.toolkit.ReflectedClass;
+import sh.siava.pixelxpert.xposed.utils.reflection.ReflectedClass;
 
 @LauncherModPack
 public class HideNavigationBarInsets extends XposedModPack {
@@ -33,7 +33,7 @@ public class HideNavigationBarInsets extends XposedModPack {
 
     @SuppressLint("DiscouragedApi")
     @Override
-    public void onPackageLoaded(XC_LoadPackage.LoadPackageParam lpParam) throws Throwable {
+    public void onPackageLoaded(io.github.libxposed.api.XposedModuleInterface.PackageReadyParam PRParam) throws Throwable {
         ReflectedClass TaskbarActivityContextClass = ReflectedClass.of("com.android.launcher3.taskbar.TaskbarActivityContext");
         TaskbarActivityContextClass
                 .before("notifyUpdateLayoutParams")

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/ScreenshotManager.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/ScreenshotManager.java
@@ -44,14 +44,17 @@ public class ScreenshotManager extends XposedModPack {
 
 	@Override
 	public void onPackageLoaded(XposedModuleInterface.PackageReadyParam PRParam) throws Throwable {
+		if (android.os.Build.VERSION.SDK_INT >= 37) return;
 		ReflectedClass NewCaptureArgsClass = ReflectedClass.ofIfPossible("android.window.ScreenCaptureInternal.CaptureArgs"); //A16QPR2
 		ReflectedClass CaptureArgsClass = ReflectedClass.ofIfPossible("android.window.ScreenCapture.CaptureArgs"); //A16QPR1
 		ReflectedClass TakeScreenshotExecutorImplClass = ReflectedClass.of("com.android.systemui.screenshot.TakeScreenshotExecutorImpl");
 		ReflectedClass ScreenshotSoundControllerImplClass = ReflectedClass.ofIfPossible("com.android.systemui.screenshot.ScreenshotSoundControllerImpl");
 
-		ReflectedClass.of(UserManager.class)
-				.before("getUserInfo")
-				.run(param -> param.args[0] = 0);
+		if (android.os.Build.VERSION.SDK_INT < 37) {
+			ReflectedClass.of(UserManager.class)
+					.before("getUserInfo")
+					.run(param -> param.args[0] = 0);
+		}
 
 		ReflectedClass ScreenshotPolicyImplClass = ReflectedClass.ofIfPossible("com.android.systemui.screenshot.ScreenshotPolicyImpl");
 
@@ -81,38 +84,40 @@ public class ScreenshotManager extends XposedModPack {
 				});
 
 
-		//17 - much easier approach: killing mediaplayer totally
-		ReflectedClass.of(MediaPlayer.class)
-				.before("start")
-				.run(param -> {
-					if(disableScreenshotSound)
-						param.setResult(null);
-				});
+		if (android.os.Build.VERSION.SDK_INT < 37) {
+			//17 - much easier approach: killing mediaplayer totally
+			ReflectedClass.of(MediaPlayer.class)
+					.before("start")
+					.run(param -> {
+						if(disableScreenshotSound)
+							param.setResult(null);
+					});
 
-		//16 qpr2
-		TakeScreenshotExecutorImplClass
-				.after("getScreenshotController")
-				.run(param -> {
-					if(disableScreenshotSound) {
-						setObjectField(
-								getObjectField(param.getResult(), "screenshotSoundController"),
-								"bgDispatcher",
-								ReflectedClass.of("kotlinx.coroutines.ExecutorCoroutineDispatcherImpl").getClazz().getConstructors()[0].newInstance(new NoExecutor()));
-					}
-				});
+			//16 qpr2
+			TakeScreenshotExecutorImplClass
+					.after("getScreenshotController")
+					.run(param -> {
+						if(disableScreenshotSound) {
+							setObjectField(
+									getObjectField(param.getResult(), "screenshotSoundController"),
+									"bgDispatcher",
+									ReflectedClass.of("kotlinx.coroutines.ExecutorCoroutineDispatcherImpl").getClazz().getConstructors()[0].newInstance(new NoExecutor()));
+						}
+					});
 
-		//16 qpr1
-		ScreenshotSoundControllerImplClass
-				.beforeConstruction()
-				.run(param -> {
-					if(disableScreenshotSound) {
-						for (int i = 0; i < param.args.length; i++) {
-							if (param.args[i].getClass().getName().toLowerCase().contains("dispatcher")) {
-								param.args[i] = ReflectedClass.of("kotlinx.coroutines.ExecutorCoroutineDispatcherImpl").getClazz().getConstructors()[0].newInstance(new NoExecutor());
+			//16 qpr1
+			ScreenshotSoundControllerImplClass
+					.beforeConstruction()
+					.run(param -> {
+						if(disableScreenshotSound) {
+							for (int i = 0; i < param.args.length; i++) {
+								if (param.args[i].getClass().getName().toLowerCase().contains("dispatcher")) {
+									param.args[i] = ReflectedClass.of("kotlinx.coroutines.ExecutorCoroutineDispatcherImpl").getClazz().getConstructors()[0].newInstance(new NoExecutor());
+								}
 							}
 						}
-					}
-				});
+					});
+		}
 	}
 
 	//Seems like an executor, but doesn't act! perfect thing


### PR DESCRIPTION
## Problem

On Android 17 QPR1 Beta 3 (CP31.260508.005), every screenshot attempt crashes \`com.android.systemui:screenshot\` with a native SIGSEGV:

\`\`\`
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x00000000ffffff00 (read)
backtrace:
  #00 art_quick_aput_obj+16       ← ART array store
  #01 nterp_op_aput_object+44     ← interpreter aput-object
  #02 <unknown>                   ← JIT-compiled hook lambda
  #03 [dalvik-jit-code-cache] (LSPosed trampoline)
\`\`\`

The crash is triggered by Xposed hook lambdas that perform \`aput-object\` (array store) operations — specifically \`param.args[0] = 0\` in the \`getUserInfo\` hook, \`param.setResult(null)\` in the \`MediaPlayer.start\` hook, and \`param.args[i] = ...\` in the \`ScreenshotSoundControllerImpl\` constructor hook. On Android 17's ART, these operations produce an invalid reference (\`0xffffff00\`) when executed via LSPosed trampolines in the screenshot process, causing a fatal SIGSEGV instead of normal execution.

The crash is reproducible 100% of the time and affects all screenshot attempts regardless of which PixelXpert features are enabled. Confirmed with both LSPosed IT (v2.0.2-it) and standard LSPosed.

Also fixes a wrong import path in \`HideNavigationBarInsets.java\` (\`utils.toolkit\` → \`utils.reflection\`).

## Fix

Add an early return guard at the top of \`onPackageLoaded\` for \`SDK_INT >= 37\`, skipping all hook registration in the screenshot process on affected builds. The \`disableScreenshotSound\` and \`ScreenshotChordInsecure\` features are silently unavailable on Android 17 until the ART 17 + Xposed \`aput-object\` incompatibility is resolved.

## Tested on

Pixel 10 Pro XL · Android 17 QPR1 Beta 3 · CP31.260508.005 · KernelSU + LSPosed · canary-494