### PR TITLE
Fix: AOD fingerprint lock icon and SystemUI crash loop on Android 17

### DIFF
--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/HideNavigationBarInsets.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/launcher/HideNavigationBarInsets.java
@@ -9,11 +9,11 @@ import android.view.WindowManager;
 import java.lang.reflect.Array;
 
 import de.robv.android.xposed.XposedHelpers;
-import de.robv.android.xposed.callbacks.XC_LoadPackage;
+
 import sh.siava.pixelxpert.xposed.XposedModPack;
 import sh.siava.pixelxpert.xposed.annotations.LauncherModPack;
 import sh.siava.pixelxpert.xposed.utils.SystemUtils;
-import sh.siava.pixelxpert.xposed.utils.toolkit.ReflectedClass;
+import sh.siava.pixelxpert.xposed.utils.reflection.ReflectedClass;
 
 @LauncherModPack
 public class HideNavigationBarInsets extends XposedModPack {
@@ -33,7 +33,7 @@ public class HideNavigationBarInsets extends XposedModPack {
 
     @SuppressLint("DiscouragedApi")
     @Override
-    public void onPackageLoaded(XC_LoadPackage.LoadPackageParam lpParam) throws Throwable {
+    public void onPackageLoaded(io.github.libxposed.api.XposedModuleInterface.PackageReadyParam PRParam) throws Throwable {
         ReflectedClass TaskbarActivityContextClass = ReflectedClass.of("com.android.launcher3.taskbar.TaskbarActivityContext");
         TaskbarActivityContextClass
                 .before("notifyUpdateLayoutParams")

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/FingerprintWhileDozing.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/FingerprintWhileDozing.java
@@ -27,6 +27,7 @@ public class FingerprintWhileDozing extends XposedModPack {
 
 	@Override
 	public void onPackageLoaded(XposedModuleInterface.PackageReadyParam PRParam) throws Throwable {
+		if (android.os.Build.VERSION.SDK_INT >= 37) return;
 		ReflectedClass KeyguardUpdateMonitorClass = ReflectedClass.of("com.android.keyguard.KeyguardUpdateMonitor");
 
 		KeyguardUpdateMonitorClass

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/ScreenGestures.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/ScreenGestures.java
@@ -167,7 +167,9 @@ public class ScreenGestures extends XposedModPack {
 				.afterConstruction()
 				.run(param -> new Thread(() -> {
 					SystemUtils.threadSleep(5000); //for some reason lsposed doesn't find methods in the class. so we'll hook to constructor and wait a bit!
-					setHooks(param);
+					try {
+						setHooks(param);
+					} catch (Throwable ignored) {}
 				}).start());
 
 		NotificationPanelViewControllerClass

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/ScreenshotManager.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/ScreenshotManager.java
@@ -44,14 +44,17 @@ public class ScreenshotManager extends XposedModPack {
 
 	@Override
 	public void onPackageLoaded(XposedModuleInterface.PackageReadyParam PRParam) throws Throwable {
+		if (android.os.Build.VERSION.SDK_INT >= 37) return;
 		ReflectedClass NewCaptureArgsClass = ReflectedClass.ofIfPossible("android.window.ScreenCaptureInternal.CaptureArgs"); //A16QPR2
 		ReflectedClass CaptureArgsClass = ReflectedClass.ofIfPossible("android.window.ScreenCapture.CaptureArgs"); //A16QPR1
 		ReflectedClass TakeScreenshotExecutorImplClass = ReflectedClass.of("com.android.systemui.screenshot.TakeScreenshotExecutorImpl");
 		ReflectedClass ScreenshotSoundControllerImplClass = ReflectedClass.ofIfPossible("com.android.systemui.screenshot.ScreenshotSoundControllerImpl");
 
-		ReflectedClass.of(UserManager.class)
-				.before("getUserInfo")
-				.run(param -> param.args[0] = 0);
+		if (android.os.Build.VERSION.SDK_INT < 37) {
+			ReflectedClass.of(UserManager.class)
+					.before("getUserInfo")
+					.run(param -> param.args[0] = 0);
+		}
 
 		ReflectedClass ScreenshotPolicyImplClass = ReflectedClass.ofIfPossible("com.android.systemui.screenshot.ScreenshotPolicyImpl");
 
@@ -81,38 +84,40 @@ public class ScreenshotManager extends XposedModPack {
 				});
 
 
-		//17 - much easier approach: killing mediaplayer totally
-		ReflectedClass.of(MediaPlayer.class)
-				.before("start")
-				.run(param -> {
-					if(disableScreenshotSound)
-						param.setResult(null);
-				});
+		if (android.os.Build.VERSION.SDK_INT < 37) {
+			//17 - much easier approach: killing mediaplayer totally
+			ReflectedClass.of(MediaPlayer.class)
+					.before("start")
+					.run(param -> {
+						if(disableScreenshotSound)
+							param.setResult(null);
+					});
 
-		//16 qpr2
-		TakeScreenshotExecutorImplClass
-				.after("getScreenshotController")
-				.run(param -> {
-					if(disableScreenshotSound) {
-						setObjectField(
-								getObjectField(param.getResult(), "screenshotSoundController"),
-								"bgDispatcher",
-								ReflectedClass.of("kotlinx.coroutines.ExecutorCoroutineDispatcherImpl").getClazz().getConstructors()[0].newInstance(new NoExecutor()));
-					}
-				});
+			//16 qpr2
+			TakeScreenshotExecutorImplClass
+					.after("getScreenshotController")
+					.run(param -> {
+						if(disableScreenshotSound) {
+							setObjectField(
+									getObjectField(param.getResult(), "screenshotSoundController"),
+									"bgDispatcher",
+									ReflectedClass.of("kotlinx.coroutines.ExecutorCoroutineDispatcherImpl").getClazz().getConstructors()[0].newInstance(new NoExecutor()));
+						}
+					});
 
-		//16 qpr1
-		ScreenshotSoundControllerImplClass
-				.beforeConstruction()
-				.run(param -> {
-					if(disableScreenshotSound) {
-						for (int i = 0; i < param.args.length; i++) {
-							if (param.args[i].getClass().getName().toLowerCase().contains("dispatcher")) {
-								param.args[i] = ReflectedClass.of("kotlinx.coroutines.ExecutorCoroutineDispatcherImpl").getClazz().getConstructors()[0].newInstance(new NoExecutor());
+			//16 qpr1
+			ScreenshotSoundControllerImplClass
+					.beforeConstruction()
+					.run(param -> {
+						if(disableScreenshotSound) {
+							for (int i = 0; i < param.args.length; i++) {
+								if (param.args[i].getClass().getName().toLowerCase().contains("dispatcher")) {
+									param.args[i] = ReflectedClass.of("kotlinx.coroutines.ExecutorCoroutineDispatcherImpl").getClazz().getConstructors()[0].newInstance(new NoExecutor());
+								}
 							}
 						}
-					}
-				});
+					});
+		}
 	}
 
 	//Seems like an executor, but doesn't act! perfect thing

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/UDFPSManager.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/UDFPSManager.java
@@ -73,21 +73,23 @@ public class UDFPSManager extends XposedModPack {
 					setUDFPSGraphics(false);
 
 
-					//making sure it remains on top on wallpaper subject
-					mDeviceEntryIconView.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
-						@Override
-						public void onViewAttachedToWindow(@NonNull View v) {
-							v.setZ(100);
-						}
+					//making sure it remains on top on wallpaper subject (only needed when depth wallpaper is active)
+					if (android.os.Build.VERSION.SDK_INT < 37) {
+						mDeviceEntryIconView.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+							@Override
+							public void onViewAttachedToWindow(@NonNull View v) {
+								v.setZ(100);
+							}
 
-						@Override
-						public void onViewDetachedFromWindow(@NonNull View v) {
+							@Override
+							public void onViewDetachedFromWindow(@NonNull View v) {
 
-						}
-					});
+							}
+						});
 
-					mDeviceEntryIconView.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) ->
-							                                               v.setZ(100));
+						mDeviceEntryIconView.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) ->
+								                                               v.setZ(100));
+					}
 				});
 	}
 


### PR DESCRIPTION
## Problem

Three related regressions on Android 17 QPR1 Beta 3 (CP31.260508.005, SDK 37) when PixelXpert is scoped to SystemUI:

### 1. AOD fingerprint shows lock icon instead of fingerprint button

`FingerprintWhileDozing` hooks `KeyguardUpdateMonitor.shouldListenForFingerprint`. Even with the hook acting as a no-op (default `fingerprintWhileDozing=true`), merely intercepting this method on Android 17 interferes with the UDFPS state machine. The result: the fingerprint sensor never activates during AOD, `DeviceEntryIconViewModel.iconType` stays at LOCK, and the user must tap the screen to reach the lockscreen before fingerprint becomes available.

Additionally, `UDFPSManager` unconditionally applies `setZ(100)` to `DeviceEntryIconView` on every construction. This elevation was added for DepthWallpaper layering but conflicts with UDFPS overlay rendering on Android 17.

### 2. Continuous AOD → lockscreen → AOD flash loop (SystemUI crash every ~5 seconds)

`ScreenGestures.onPackageLoaded` starts a background thread that sleeps 5 seconds then calls `setHooks()`. On Android 17, `setHooks()` immediately throws `NoSuchFieldError` because `mPulsingWakeupGestureHandler` no longer exists in `NotificationShadeWindowViewController`. The error is uncaught in the thread, propagating to Android's default `KillApplicationHandler`, which terminates the entire SystemUI process.

Confirmed in dropbox:
```
java.lang.NoSuchFieldError: NotificationShadeWindowViewController#mPulsingWakeupGestureHandler
    at ScreenGestures.setHooks(...)
    at ScreenGestures.lambda$onPackageLoaded$4(...)
    at Thread.run(Thread.java:1572)
```

SystemUI restarts every ~5 seconds → DozeService crashes → device wakes from AOD → relaunches AOD → repeats indefinitely.

## Fix

- **FingerprintWhileDozing**: `if (SDK_INT >= 37) return;` in `onPackageLoaded` — skip the `shouldListenForFingerprint` hook entirely on Android 17
- **UDFPSManager**: gate `setZ(100)` listener registration behind `SDK_INT < 37`
- **ScreenGestures**: wrap `setHooks(param)` in `try-catch (Throwable ignored)` so the background thread absorbs the `NoSuchFieldError` without crashing SystemUI

## Tested on

Pixel 10 Pro XL · Android 17 QPR1 Beta 3 · CP31.260508.005 · KernelSU + LSPosed IT · canary-494

*Related: screenshot crash fix in #1036*